### PR TITLE
Boost and VexCL configuration fixes

### DIFF
--- a/m4/common/boost.m4
+++ b/m4/common/boost.m4
@@ -329,14 +329,14 @@ CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
 AC_CACHE_CHECK([for the Boost $1 library], [Boost_lib],
                [_BOOST_FIND_LIBS($@)])
 case $Boost_lib in #(
-  (no) _AC_MSG_LOG_CONFTEST
-    AC_MSG_ERROR([cannot find the flags to link with Boost $1])
+  (yes) _AC_MSG_LOG_CONFTEST
+    AC_DEFINE(AS_TR_CPP([HAVE_BOOST_$1]), [1], [Defined if the Boost $1 library is available])dnl
+    AC_SUBST(AS_TR_CPP([BOOST_$1_LDFLAGS]), [$Boost_lib_LDFLAGS])dnl
+    AC_SUBST(AS_TR_CPP([BOOST_$1_LDPATH]), [$Boost_lib_LDPATH])dnl
+    AC_SUBST([BOOST_LDPATH], [$Boost_lib_LDPATH])dnl
+    AC_SUBST(AS_TR_CPP([BOOST_$1_LIBS]), [$Boost_lib_LIBS])dnl
     ;;
 esac
-AC_SUBST(AS_TR_CPP([BOOST_$1_LDFLAGS]), [$Boost_lib_LDFLAGS])dnl
-AC_SUBST(AS_TR_CPP([BOOST_$1_LDPATH]), [$Boost_lib_LDPATH])dnl
-AC_SUBST([BOOST_LDPATH], [$Boost_lib_LDPATH])dnl
-AC_SUBST(AS_TR_CPP([BOOST_$1_LIBS]), [$Boost_lib_LIBS])dnl
 CPPFLAGS=$boost_save_CPPFLAGS
 AS_VAR_POPDEF([Boost_lib])dnl
 AS_VAR_POPDEF([Boost_lib_LDFLAGS])dnl

--- a/m4/common/boost.m4
+++ b/m4/common/boost.m4
@@ -570,9 +570,11 @@ BOOST_DEFUN([Chrono],
 [# Do we have to check for Boost.System?  This link-time dependency was
 # added as of 1.35.0.  If we have a version <1.35, we must not attempt to
 # find Boost.System as it didn't exist by then.
+if test "x$boost_major_version" != x; then
 if test $boost_major_version -ge 135; then
   BOOST_SYSTEM([$1])
 fi # end of the Boost.System check.
+fi
 boost_filesystem_save_LIBS=$LIBS
 boost_filesystem_save_LDFLAGS=$LDFLAGS
 m4_pattern_allow([^BOOST_SYSTEM_(LIBS|LDFLAGS)$])dnl
@@ -755,9 +757,11 @@ BOOST_DEFUN([Filesystem],
 [# Do we have to check for Boost.System?  This link-time dependency was
 # added as of 1.35.0.  If we have a version <1.35, we must not attempt to
 # find Boost.System as it didn't exist by then.
+if test "x$boost_major_version" != x; then
 if test $boost_major_version -ge 135; then
   BOOST_SYSTEM([$1])
 fi # end of the Boost.System check.
+fi
 boost_filesystem_save_LIBS=$LIBS
 boost_filesystem_save_LDFLAGS=$LDFLAGS
 m4_pattern_allow([^BOOST_SYSTEM_(LIBS|LDFLAGS)$])dnl
@@ -1169,9 +1173,11 @@ boost_thread_save_LIBS=$LIBS
 boost_thread_save_LDFLAGS=$LDFLAGS
 boost_thread_save_CPPFLAGS=$CPPFLAGS
 # Link-time dependency from thread to system was added as of 1.49.0.
+if test "x$boost_major_version" != x; then
 if test $boost_major_version -ge 149; then
 BOOST_SYSTEM([$1])
 fi # end of the Boost.System check.
+fi
 m4_pattern_allow([^BOOST_SYSTEM_(LIBS|LDFLAGS)$])dnl
 LIBS="$LIBS $BOOST_SYSTEM_LIBS $boost_cv_pthread_flag"
 LDFLAGS="$LDFLAGS $BOOST_SYSTEM_LDFLAGS"
@@ -1182,10 +1188,12 @@ CPPFLAGS="$CPPFLAGS $boost_cv_pthread_flag"
 # possibly new versions of GCC on mingw I am assuming it's Boost's change for
 # now and I am setting version to 1.48, for lack of knowledge as to when this
 # change occurred.
+if test "x$boost_major_version" != x; then
 if test $boost_major_version -lt 148; then
   case $host_os in
     (*mingw*) boost_thread_lib_ext=_win32;;
   esac
+fi
 fi
 BOOST_FIND_LIBS([thread], [thread$boost_thread_lib_ext],
                 [$1],

--- a/m4/common/vexcl.m4
+++ b/m4/common/vexcl.m4
@@ -84,11 +84,31 @@ if test "${with_vexcl}" != no ; then
 
     found_boost=yes
     BOOST_REQUIRE([1.47],[found_boost=no]) # Chrono introduced in 1.47
+
     BOOST_CHRONO
+    if test "x$boost_cv_lib_chrono" != xyes; then
+      found_boost=no
+    fi
+
     BOOST_DATE_TIME
+    if test "x$boost_cv_lib_date_time" != xyes; then
+      found_boost=no
+    fi
+
     BOOST_FILESYSTEM
+    if test "x$boost_cv_lib_filesystem" != xyes; then
+      found_boost=no
+    fi
+
     BOOST_SYSTEM
+    if test "x$boost_cv_lib_system" != xyes; then
+      found_boost=no
+    fi
+
     BOOST_THREADS
+    if test "x$boost_cv_lib_threads" != xyes; then
+      found_boost=no
+    fi
 
     # Make sure we have OpenCL support
     AX_CHECK_CL([C++])

--- a/test/navier_unit.h
+++ b/test/navier_unit.h
@@ -142,6 +142,12 @@ int main(void)
           vrnorm_max = std::max(vrnorm, vrnorm_max);
           prnorm_max = std::max(prnorm, prnorm_max);
           ernorm_max = std::max(ernorm, ernorm_max);
+#else
+          // Avoid "set but not used" variable warnings;
+          (void) s2u;
+          (void) s2v;
+          (void) s2p;
+          (void) s2e;
 #endif // METAPHYSICL_HAVE_MASA
 
 	}

--- a/test/pde_unit.h
+++ b/test/pde_unit.h
@@ -106,6 +106,12 @@ int main(void)
           vrnorm_max = std::max(vrnorm, vrnorm_max);
           prnorm_max = std::max(prnorm, prnorm_max);
           ernorm_max = std::max(ernorm, ernorm_max);
+#else
+          // Avoid "set but not used" variable warnings;
+          (void) s2u;
+          (void) s2v;
+          (void) s2p;
+          (void) s2e;
 #endif // METAPHYSICL_HAVE_MASA
 
 	}


### PR DESCRIPTION
Ported upstream from https://github.com/libMesh/libmesh/pull/1615 and https://github.com/libMesh/libmesh/pull/1623; one fix originated from @nylan at https://github.com/tsuna/boost.m4/pull/86

Thanks to @Hellium0 for helping diagnose the link failure issues and @jwpeterson for finding and fixing the unset variable bug.