### PR TITLE
Allow manually (and improve auto) disabling modern C++

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -54,14 +54,40 @@ AC_PROG_CXX
 dnl Added for AX_CODE_COVERAGE macro to work correctly, even though there's no Fortran here.
 AC_PROG_FC
 
-dnl We're going to need at least C++14 for two of our test cases
-AX_CXX_COMPILE_STDCXX(14,noext,optional)
+dnl We're going to need at least C++11 for some of our test cases
+AC_ARG_ENABLE(cxx11,
+              AC_HELP_STRING([--disable-cxx11],
+                             [build without C++11 support]),
+              [AS_CASE("${enableval}",
+                       [yes], [enablecxx11=yes],
+                       [no],  [enablecxx11=no],
+                       [AC_MSG_ERROR(bad value ${enableval} for --disable-cxx11)])],
+              [enablecxx11=auto])
+
+dnl We're going to need at least C++14 for some of our test cases
+AC_ARG_ENABLE(cxx14,
+              AC_HELP_STRING([--disable-cxx14],
+                             [build without C++14 support]),
+              [AS_CASE("${enableval}",
+                       [yes], [enablecxx14=yes],
+                       [no],  [enablecxx14=no],
+                       [AC_MSG_ERROR(bad value ${enableval} for --disable-cxx14)])],
+              [enablecxx14=auto])
+
+AS_IF([test x$enablecxx14 = xyes -a x$enablecxx11 = xno],
+      [AC_MSG_ERROR(can't enable C++14 while disabling C++11)])
+
+AS_IF([test x$enablecxx14 != xno -a x$enablecxx11 != xno],
+      [AX_CXX_COMPILE_STDCXX(14,noext,optional)],
+      [HAVE_CXX14=0])
+
 AM_CONDITIONAL(CXX14_ENABLED,test x$HAVE_CXX14 = x1)
 
-dnl We're going to need at least C++11 for another of our test cases
 AS_IF([test x$HAVE_CXX14 = x1],
       [HAVE_CXX11=1],
-      [AX_CXX_COMPILE_STDCXX(11,noext,optional)])
+      [AS_IF([test x$enablecxx11 != xno],
+             [AX_CXX_COMPILE_STDCXX(11,noext,optional)],
+             [HAVE_CXX11=0])])
 AM_CONDITIONAL(CXX11_ENABLED,test x$HAVE_CXX11 = x1)
 
 dnl -Wall warnings, -Wall the time.
@@ -75,7 +101,9 @@ dnl Optional check for MASA
 AX_PATH_MASA(0.20,no)
 
 dnl Optional check for VexCL
-AX_PATH_VEXCL(0.0.0, no)
+AS_IF([test x$HAVE_CXX11 = x1],
+      [AX_PATH_VEXCL(0.0.0, no)],
+      [AM_CONDITIONAL(VEXCL_ENABLED,false)])
 if (test x$HAVE_VEXCL = x1); then
   antioch_optional_test_INCLUDES="$VEXCL_CPPFLAGS $antioch_optional_test_INCLUDES"
   antioch_optional_test_LDFLAGS="$VEXCL_LDFLAGS $antioch_optional_test_LDFLAGS"

--- a/m4/common/ax_cxx_compile_stdcxx.m4
+++ b/m4/common/ax_cxx_compile_stdcxx.m4
@@ -459,6 +459,9 @@ m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_14], [[
 
 #else
 
+// C++14 clang with C++11 libstdc++ dies on this header
+#include <iostream>
+
 namespace cxx14
 {
 


### PR DESCRIPTION
See https://github.com/libMesh/libmesh/pull/1845

@jwpeterson, could you give this a try and see if it catches the bug with your old clang/libstdc++ combination?  If it works then we'll turn it into 0.3.1, rebootstrap, etc.