### PR TITLE
Allow canonical copy constructor/assignment argument (const &) for DualNumberSurrogate

### DIFF
--- a/src/numerics/include/metaphysicl/dualnumber_surrogate.h
+++ b/src/numerics/include/metaphysicl/dualnumber_surrogate.h
@@ -69,9 +69,8 @@ inline DualNumberSurrogate<T, D>::DualNumberSurrogate(DualNumberSurrogate<T, D> 
 }
 
 template <typename T, typename D>
-template <typename T2, typename D2>
 inline DualNumberSurrogate<T, D> &
-DualNumberSurrogate<T, D>::operator=(DualNumberSurrogate<T2, D2> & dns)
+DualNumberSurrogate<T, D>::operator=(const DualNumberSurrogate<T, D> & dns)
 {
   _value = dns.value();
   auto size = _derivatives.size();

--- a/src/numerics/include/metaphysicl/dualnumber_surrogate_decl.h
+++ b/src/numerics/include/metaphysicl/dualnumber_surrogate_decl.h
@@ -33,8 +33,7 @@ public:
 
   DualNumberSurrogate(DualNumberSurrogate<T, D> && dns);
 
-  template <typename T2, typename D2>
-  DualNumberSurrogate<T, D> & operator=(DualNumberSurrogate<T2, D2> & dns);
+  DualNumberSurrogate& operator=(const DualNumberSurrogate<T, D> & dns);
 
   template <typename T2, typename D2>
   DualNumberSurrogate<T, D> & operator=(const DualNumberSurrogate<T2, D2> & dns);


### PR DESCRIPTION
Without copy constructor/assignment operator that accepts a `const` argument, instantiations of stl containers that contain `DualNumberSurrogates` can error out. I've seen this in MOOSE work. I'm not quite sure why these errors aren't produced in the `nd_derivs_unit` test because it instantiates a `std::map` with `DualNumberSurrogate` values.