### PR TITLE
DualNumber construction/assignment from DualNumberSurrogate

### DIFF
--- a/src/numerics/include/metaphysicl/dualnumber.h
+++ b/src/numerics/include/metaphysicl/dualnumber.h
@@ -30,6 +30,7 @@
 #define METAPHYSICL_DUALNUMBER_H
 
 #include "metaphysicl/dualnumber_decl.h"
+#include "metaphysicl/dualnumber_surrogate.h"
 
 namespace MetaPhysicL {
 
@@ -79,6 +80,29 @@ DualNumber<T,D>::operator=(const NotADuckDualNumber<T2,D2> & nd_dn)
 {
   _val = nd_dn.value();
   _deriv = nd_dn.derivatives();
+  return *this;
+}
+
+template <typename T, typename D>
+template <typename T2, typename D2>
+inline
+DualNumber<T,D>::DualNumber(const DualNumberSurrogate<T2,D2> & dns) : _val(dns.value())
+{
+  auto size = dns.derivatives().size();
+  for (decltype(size) i = 0; i < size; ++i)
+    _deriv[i] = *dns.derivatives()[i];
+}
+
+template <typename T, typename D>
+template <typename T2, typename D2>
+inline
+DualNumber<T,D> &
+DualNumber<T,D>::operator=(const DualNumberSurrogate<T2,D2> & dns)
+{
+  _val = dns.value();
+  auto size = dns.derivatives().size();
+  for (decltype(size) i = 0; i < size; ++i)
+    _deriv[i] = *dns.derivatives()[i];
   return *this;
 }
 

--- a/src/numerics/include/metaphysicl/dualnumber_decl.h
+++ b/src/numerics/include/metaphysicl/dualnumber_decl.h
@@ -41,6 +41,8 @@ namespace MetaPhysicL {
 
 template <typename T, typename D=T>
 class NotADuckDualNumber;
+template <typename T, typename D>
+class DualNumberSurrogate;
 
 template <typename T, typename D=T>
 class DualNumber : public safe_bool<DualNumber<T,D> >
@@ -74,6 +76,12 @@ public:
 
   template <typename T2, typename D2>
   DualNumber & operator=(const NotADuckDualNumber<T2,D2> & nd_dn);
+
+  template <typename T2, typename D2>
+  explicit DualNumber(const DualNumberSurrogate<T2, D2> & dns);
+
+  template <typename T2, typename D2>
+  DualNumber & operator= (const DualNumberSurrogate<T2, D2> & dns);
 
   T& value();
 

--- a/test/nd_derivs_unit.C
+++ b/test/nd_derivs_unit.C
@@ -224,8 +224,21 @@ main()
   nd_derivs_expect_near(tensor_ad_prop.derivatives()[1](2, 2), -326880, tol);
 
   DualNumberSurrogate<double, NumberArray<2, double*>> dns(0);
+  double zero(0);
+  dns.derivatives()[0] = &zero;
+  dns.derivatives()[1] = &zero;
   DualNumberSurrogate<double, NumberArray<2, double*>> dns2(dns);
   DualNumberSurrogate<double, NumberArray<2, double*>> dns3(scalar_ad_prop);
+
+  DualNumber<double, NumberArray<2, double>> new_scalar_ad_prop(dns);
+  nd_derivs_expect_near(new_scalar_ad_prop.value(), 0, tol);
+  nd_derivs_expect_near(new_scalar_ad_prop.derivatives()[0], 0, tol);
+  nd_derivs_expect_near(new_scalar_ad_prop.derivatives()[1], 0, tol);
+
+  new_scalar_ad_prop = dns3;
+  nd_derivs_expect_near(new_scalar_ad_prop.value(), scalar_ad_prop.value(), tol);
+  nd_derivs_expect_near(new_scalar_ad_prop.derivatives()[0], scalar_ad_prop.derivatives()[0], tol);
+  nd_derivs_expect_near(new_scalar_ad_prop.derivatives()[1], scalar_ad_prop.derivatives()[1], tol);
 
   return returnval;
 }


### PR DESCRIPTION
Needed for operations like:
```c++
DualNumber<double> new_dn = NotADuckDualNumber<TensorValue<double>>(TensorValue<double>())(0, 0)
```