### PR TITLE
Fix dangling reference return in DSNB::operator[]

### DIFF
--- a/src/numerics/include/metaphysicl/dynamicsparsenumberbase.h
+++ b/src/numerics/include/metaphysicl/dynamicsparsenumberbase.h
@@ -156,7 +156,7 @@ DynamicSparseNumberBase<T,I,SubType>::operator[](index_value_type i)
 
   // Bad user code could make this fail.  We'd prefer to catch OOB
   // writes at *write* time but at least we can catch at read time.
-  metaphysicl_assert(zero == 0);
+  metaphysicl_assert(zero == T(0));
 
   std::size_t rq = runtime_index_query(i);
   if (rq == std::numeric_limits<std::size_t>::max())

--- a/src/numerics/include/metaphysicl/dynamicsparsenumberbase.h
+++ b/src/numerics/include/metaphysicl/dynamicsparsenumberbase.h
@@ -151,22 +151,28 @@ template <typename T, typename I, template <typename, typename> class SubType>
 inline
 T&
 DynamicSparseNumberBase<T,I,SubType>::operator[](index_value_type i)
-{ return this->query(i); }
+{
+  static T zero = 0;
+
+  // Bad user code could make this fail.  We'd prefer to catch OOB
+  // writes at *write* time but at least we can catch at read time.
+  metaphysicl_assert(zero == 0);
+
+  std::size_t rq = runtime_index_query(i);
+  if (rq == std::numeric_limits<std::size_t>::max())
+    return zero;
+  return _data[rq];
+}
 
 template <typename T, typename I, template <typename, typename> class SubType>
 inline
 const T&
 DynamicSparseNumberBase<T,I,SubType>::operator[](index_value_type i) const
-{ return _data[runtime_index_of(i)]; }
-
-template <typename T, typename I, template <typename, typename> class SubType>
-inline
-T
-DynamicSparseNumberBase<T,I,SubType>::query(index_value_type i) const
 {
+  static const T zero = 0;
   std::size_t rq = runtime_index_query(i);
   if (rq == std::numeric_limits<std::size_t>::max())
-    return 0;
+    return zero;
   return _data[rq];
 }
 

--- a/src/numerics/include/metaphysicl/dynamicsparsenumberbase_decl.h
+++ b/src/numerics/include/metaphysicl/dynamicsparsenumberbase_decl.h
@@ -111,8 +111,6 @@ public:
 
   const T& operator[](index_value_type i) const;
 
-  T query(index_value_type i) const;
-
   template <unsigned int i>
   typename entry_type<i>::type& get();
 


### PR DESCRIPTION
This isn't a great fix but it's the best we can do while still
returning T&

Pinging @lindsayad