### PR TITLE
Don't default initialize NumberArray data

### DIFF
--- a/src/numerics/include/metaphysicl/dualnumber.h
+++ b/src/numerics/include/metaphysicl/dualnumber.h
@@ -131,12 +131,6 @@ DualNumber<T,D>::operator=(const T2 & scalar)
 //
 // Member function definitions
 //
-
-template <typename T, typename D>
-inline
-DualNumber<T,D>::DualNumber() :
-  _val(), _deriv() {}
-
 template <typename T, typename D>
 template <typename T2>
 inline

--- a/src/numerics/include/metaphysicl/dualnumber_decl.h
+++ b/src/numerics/include/metaphysicl/dualnumber_decl.h
@@ -52,7 +52,7 @@ public:
 
   typedef D derivatives_type;
 
-  DualNumber();
+  DualNumber() = default;
 
   template <typename T2>
   DualNumber(const T2& val);

--- a/src/numerics/include/metaphysicl/numberarray.h
+++ b/src/numerics/include/metaphysicl/numberarray.h
@@ -79,7 +79,7 @@ public:
     typedef NumberArray<N2, T> other;
   };
 
-  NumberArray() : _data() {}
+  NumberArray() = default;
 
   NumberArray(const T& val)
     { std::fill(_data, _data+N, val); }

--- a/src/numerics/include/metaphysicl/numbervector.h
+++ b/src/numerics/include/metaphysicl/numbervector.h
@@ -81,7 +81,7 @@ public:
     typedef NumberVector<N2, T> other;
   };
 
-  NumberVector() {}
+  NumberVector() = default;
 
   NumberVector(const T& val)
     { std::fill(_data, _data+N, val); }


### PR DESCRIPTION
I know we have #13, and I was the one to make the change for `NumberArray` in #11, but I do think we should allow intentional uninitialized data. I see a lot of `bzero` show up in profiling. I don't think that a user who calls `NumberArray a;` and `NumberArray a = NumberArray()` should expect different behavior. I re-read [this discussion](https://github.com/roystgnr/MetaPhysicL/pull/11#discussion_r212089810) quite a few times this morning and had @jwpeterson look at it as well; I guess I'm just not familiar with the second idiom. We both look at the first and second expressions in that discussion and expect to observe the exact same behavior between the two.