### PR TITLE
Change derivative of std::pow

### DIFF
--- a/src/numerics/include/metaphysicl/dualnumber.h
+++ b/src/numerics/include/metaphysicl/dualnumber.h
@@ -524,7 +524,7 @@ funcname (const DualNumber<T,D>& a, const T2& b) \
 // is 0; we should have a contribution of 0 from those, not NaN.
 DualNumber_std_binary(pow,
   funcval * (b.value() * a.derivatives() / a.value() +
-  MetaPhysicL::if_else(b.derivatives(), b.derivatives() * std::log(a.value()), b.derivatives())))
+  b.derivatives() * std::log(a.value())))
 DualNumber_std_binary(atan2,
   (b.value() * a.derivatives() - a.value() * b.derivatives()) /
   (b.value() * b.value() + a.value() * a.value()))

--- a/test/derivs_unit.C
+++ b/test/derivs_unit.C
@@ -129,7 +129,7 @@ int vectester (void)
 
   // And now for derivatives tests
 
-  one_test(derivatives(pow(sin(random_vec-2),2)) -
+  one_test(derivatives(pow(abs(sin(random_vec-2)),2)) -
 	   2*sin(random_vec-2)*cos(random_vec-2));
 
   one_test(derivatives(cos(2*random_vec)) + 2*sin(2*random_vec));


### PR DESCRIPTION
I have to be honest that I don't understand the `if_else` condition here. Why should it key off of `b.derivatives()`? If `b.derivatives()` is less than zero, than we no longer have the general derivative form?

So in it's current form, the std::pow template will yield a compilation error with any `D` other than a Scalar type, which makes sense. I could create another overload that does element wise checking of `b.derivatives()` (if that's really the thing to key on?).

But, in my opinion, we should just insert NaNs whenever `a` is negative for the reason of the first convention discussed [here](https://math.stackexchange.com/a/317546/408963).