### PR TITLE
Fixing warning with clang 7.x

### DIFF
--- a/src/numerics/include/metaphysicl/dualnumber.h
+++ b/src/numerics/include/metaphysicl/dualnumber.h
@@ -369,7 +369,7 @@ DualNumber<T,D> funcname (DualNumber<T,D> && in) \
   precalc; \
   in.derivatives() *= derivative; \
   in.value() = funcval; \
-  return in; \
+  return std::move(in); \
 }
 
 #define DualNumber_equiv_unary(funcname, equivalent) \
@@ -398,7 +398,7 @@ DualNumber<T,D> funcname (DualNumber<T,D> in) \
   precalc; \
   in.derivatives() *= derivative; \
   in.value() = funcval; \
-  return in; \
+  return std::move(in); \
 }
 
 #define DualNumber_equiv_unary(funcname, equivalent) \


### PR DESCRIPTION
clang 7.x suggest to use std::move. Otherwise is generates a warning
so when people have -Werror enabled the build fails for them.