### PR TITLE
error Unknown option

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -113,7 +113,7 @@ STAMPED_FILES = $(libmetaphysicl_la_SOURCES) $(include_HEADERS) $(metaphysicl_ve
 BUILT_SOURCES = .license.stamp
 
 .license.stamp: $(top_srcdir)/LICENSE
-	$(top_srcdir)/src/common/lic_utils/update_license.pl -S=$(top_srcdir)/src $(top_srcdir)/LICENSE $(STAMPED_FILES)
+	$(top_srcdir)/src/common/lic_utils/update_license.pl -S $(top_srcdir)/src $(top_srcdir)/LICENSE $(STAMPED_FILES)
 	echo 'updated source license headers' >$@
 
 CLEANFILES += .license.stamp


### PR DESCRIPTION
build libmesh in mingw64

> Unknown option: S=../src

https://github.com/roystgnr/MetaPhysicL/blob/0464c02f47aecb9c4c28efc6e342bc02df58a627/src/common/lic_utils/update_license.pl#L31

 ``print "  -S dir               use dir as location of source-files\n";``