### PR TITLE
Create metaphysicl_dbg_var to eliminate compiler warnings 

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,6 +26,7 @@ include_HEADERS =
 include_HEADERS += core/include/metaphysicl/compare_types.h
 include_HEADERS += core/include/metaphysicl/ct_set.h
 include_HEADERS += core/include/metaphysicl/ct_types.h
+include_HEADERS += core/include/metaphysicl/metaphysicl_common.h
 
 # graphs
 include_HEADERS += graphs/include/metaphysicl/physics.h

--- a/src/core/include/metaphysicl/metaphysicl_common.h
+++ b/src/core/include/metaphysicl/metaphysicl_common.h
@@ -1,0 +1,12 @@
+#ifndef METAPHYSICL_COMMON_H
+#define METAPHYSICL_COMMON_H
+
+// The libmesh_dbg_var() macro indicates that an argument to a function
+// is used only in debug mode (i.e., when NDEBUG is not defined).
+#ifndef NDEBUG
+#define metaphysicl_dbg_var(var) var
+#else
+#define metaphysicl_dbg_var(var)
+#endif
+
+#endif // METAPHYSICL_COMMON_H

--- a/src/numerics/include/metaphysicl/dynamicsparsenumbervector.h
+++ b/src/numerics/include/metaphysicl/dynamicsparsenumbervector.h
@@ -31,6 +31,7 @@
 
 #include "metaphysicl/dynamicsparsenumbervector_decl.h"
 #include "metaphysicl/dynamicsparsenumberbase.h"
+#include "metaphysicl/metaphysicl_common.h"
 
 namespace MetaPhysicL {
 
@@ -40,7 +41,7 @@ DynamicSparseNumberVector<T,I>::DynamicSparseNumberVector() {}
 
 template <typename T, typename I>
 inline
-DynamicSparseNumberVector<T,I>::DynamicSparseNumberVector(const T& val) {
+DynamicSparseNumberVector<T,I>::DynamicSparseNumberVector(const T& metaphysicl_dbg_var(val)) {
   // This makes no sense unless val is 0!
 #ifndef NDEBUG
   if (val)
@@ -51,7 +52,7 @@ DynamicSparseNumberVector<T,I>::DynamicSparseNumberVector(const T& val) {
 template <typename T, typename I>
 template <typename T2>
 inline
-DynamicSparseNumberVector<T,I>::DynamicSparseNumberVector(const T2& val) {
+DynamicSparseNumberVector<T,I>::DynamicSparseNumberVector(const T2& metaphysicl_dbg_var(val)) {
   // This makes no sense unless val is 0!
 #ifndef NDEBUG
   if (val)


### PR DESCRIPTION
Currently when compiling in optimized modes we will get warnings in some functions that only use their parameters in debug mode. I created `metaphysicl_dbg_var` as an analog to `libmesh_dbg_var` to address this issue.