### PR TITLE
Fix std::pow(0,b>1) derivatives

### DIFF
--- a/src/numerics/include/metaphysicl/dualexpression.h
+++ b/src/numerics/include/metaphysicl/dualexpression.h
@@ -839,11 +839,11 @@ DualExpression_equiv_binary(funcname##l, funcname)
 // if_else is necessary here to handle cases where a is negative but
 // b' is 0; we should have a contribution of 0 from those, not NaN.
 DualExpression_std_binary(pow,
-  std::pow(a.value(), b.value()) * (b.value() * a.derivatives() / a.value() +
-  MetaPhysicL::if_else(b.derivatives(), b.derivatives() * std::log(a.value()), b.derivatives())),
+  std::pow(a.value(), b.value() - 1) * (b.value() * a.derivatives() +
+  MetaPhysicL::if_else(b.derivatives(), b.derivatives() * std::log(a.value()) * a.value(), b.derivatives())),
   std::pow(a, b.value()) *
   MetaPhysicL::if_else(b.derivatives(), (b.derivatives() * std::log(a)), b.derivatives()),
-  std::pow(a.value(), b) * (b * a.derivatives() / a.value())
+  std::pow(a.value(), b - 1) * (b * a.derivatives())
   )
 DualExpression_std_binary(atan2,
   (b.value() * a.derivatives() - a.value() * b.derivatives()) /

--- a/src/numerics/include/metaphysicl/dualnumber.h
+++ b/src/numerics/include/metaphysicl/dualnumber.h
@@ -632,8 +632,8 @@ DualNumber_equiv_binary(funcname##l, funcname)
 // if_else is necessary here to handle cases where a is negative but b
 // is 0; we should have a contribution of 0 from those, not NaN.
 DualNumber_std_binary(pow,
-  funcval * (b.value() * a.derivatives() / a.value() +
-  MetaPhysicL::if_else(b.derivatives(), b.derivatives() * std::log(a.value()), b.derivatives())))
+  std::pow(a.value(), b.value() - 1) * (b.value() * a.derivatives() +
+  MetaPhysicL::if_else(b.derivatives(), b.derivatives() * std::log(a.value()) * a.value(), b.derivatives())))
 DualNumber_std_binary(atan2,
   (b.value() * a.derivatives() - a.value() * b.derivatives()) /
   (b.value() * b.value() + a.value() * a.value()))


### PR DESCRIPTION
We were previously trying to avoid an extra pow call by simply
dividing the result of the original call by the base, but this gives
0/0 => NaN when the base is 0, even for the b > 1 case where the
derivative *should* be well-defined.

Hopefully this fixes the aside @dschwen pointed out in #35.

This ends up forcing an extra std::pow call in the DualNumber case, which isn't great for efficiency, but isn't the yet-another-if_else efficiency disaster I was fearing.