### PR TITLE
Reduce temporary creation

### DIFF
--- a/src/numerics/include/metaphysicl/dualnumber.h
+++ b/src/numerics/include/metaphysicl/dualnumber.h
@@ -146,25 +146,7 @@ DualNumber<T,D>::DualNumber(const T2& val,
   _val  (DualNumberConstructor<T,D>::value(val,deriv)),
   _deriv(DualNumberConstructor<T,D>::deriv(val,deriv)) {}
 
-// // Some helpers for reducing temporary creation and memset, memcpy calls
-
-// template <typename T>
-// struct HasBracketOperator
-// {
-//   template <typename C>
-//   static constexpr decltype(std::declval<C>()[0], bool()) test(int /*unused*/)
-//   {
-//     return true;
-//   }
-
-//   template <typename C>
-//   static constexpor bool test(...)
-//   {
-//     return false;
-//   }
-
-//   static constexpr bool value = test<T>(int());
-// };
+// Some helpers for reducing temporary creation and memset, memcpy calls
 
 template <typename T,
           template <std::size_t, typename>

--- a/src/numerics/include/metaphysicl/dualnumber.h
+++ b/src/numerics/include/metaphysicl/dualnumber.h
@@ -158,8 +158,13 @@ template <typename T, typename D, typename T2, typename D2>
 void
 calcMultiplyDerivs(DualNumber<T, D> & out, const DualNumber<T2,D2>& in)
 {
-  for (unsigned int i = 0; i < in.derivatives().size(); i++)
-    out.derivatives()[i] = out.derivatives()[i] * in.value() + out.value() * in.derivatives()[i];
+  auto& din = in.derivatives();
+  auto& dout = out.derivatives();
+  const auto vin = in.value();
+  const auto vout = out.value();
+  const auto n = dout.size();
+  for (int i = 0; i < n; i++)
+    dout[i] = vin * dout[i] + vout * din[i];
 }
 template <typename T, typename T2>
 void


### PR DESCRIPTION
This is mostly @rwcarlsen's work. I'm going to let him give a more detailed description for why this is desired, but it's mostly for avoiding memset and memcpy calls as well as encouraging vectorization.

@rwcarlsen, can you check and see whether you're still getting the desired performance with the commits I added?