### PR TITLE
Allow operations between std::complex<T> and T

### DIFF
--- a/src/core/include/metaphysicl/compare_types.h
+++ b/src/core/include/metaphysicl/compare_types.h
@@ -328,7 +328,10 @@ struct CompareTypes<std::complex<T>, T, reverseorder, Enable> {
         CompareTypes_super(std::complex<mysuper>, std::complex<mysub>, std::complex<mysuper>)
 
 #define CompareTypes_single(mytype) \
-        CompareTypes_super(mytype, mytype, mytype)
+        CompareTypes_super(mytype, mytype, mytype); \
+        CompareTypes_super(std::complex<mytype>, mytype, std::complex<mytype>); \
+        CompareTypes_super(mytype, std::complex<mytype>, std::complex<mytype>); \
+        CompareTypes_super(std::complex<mytype>, std::complex<mytype>, std::complex<mytype>)
 
 CompareTypes_single(unsigned char);
 CompareTypes_single(unsigned short);

--- a/test/complex_derivs_unit.C
+++ b/test/complex_derivs_unit.C
@@ -40,76 +40,85 @@ main()
   double tol = 1e-8;
   int returnval = 0;
 
-  DualNumber<std::complex<double>, NumberArray<2, std::complex<double>>> cdn{
-      std::complex<double>{1., 1.}};
+  {
+    DualNumber<std::complex<double>, NumberArray<2, std::complex<double>>> cdn{
+        std::complex<double>{1., 1.}};
 
-  DualNumber<double, NumberArray<2, double>> dn_real = std::real(cdn);
-  expect_near(dn_real.value(), 1, tol);
-  expect_nan_dualnumber(dn_real);
+    DualNumber<double, NumberArray<2, double>> dn_real = std::real(cdn);
+    expect_near(dn_real.value(), 1, tol);
+    expect_nan_dualnumber(dn_real);
 
-  DualNumber<double, NumberArray<2, double>> dn_imag = std::imag(cdn);
-  expect_near(dn_imag.value(), 1, tol);
-  expect_nan_dualnumber(dn_imag);
+    DualNumber<double, NumberArray<2, double>> dn_imag = std::imag(cdn);
+    expect_near(dn_imag.value(), 1, tol);
+    expect_nan_dualnumber(dn_imag);
 
-  DualNumber<double, NumberArray<2, double>> dn_norm = std::norm(cdn);
-  expect_near(dn_norm.value(), 2, tol);
-  expect_nan_dualnumber(dn_norm);
+    DualNumber<double, NumberArray<2, double>> dn_norm = std::norm(cdn);
+    expect_near(dn_norm.value(), 2, tol);
+    expect_nan_dualnumber(dn_norm);
 
-  DualNumber<double, NumberArray<2, double>> dn_abs = std::abs(cdn);
-  expect_near(dn_abs.value(), sqrt2, tol);
-  expect_nan_dualnumber(dn_abs);
+    DualNumber<double, NumberArray<2, double>> dn_abs = std::abs(cdn);
+    expect_near(dn_abs.value(), sqrt2, tol);
+    expect_nan_dualnumber(dn_abs);
 
-  DualNumber<std::complex<double>, NumberArray<2, std::complex<double>>> dn_conj = std::conj(cdn);
-  expect_near(dn_conj.value().real(), 1, tol);
-  expect_near(dn_conj.value().imag(), -1, tol);
-  expect_complex_nan_dualnumber(dn_conj);
+    DualNumber<std::complex<double>, NumberArray<2, std::complex<double>>> dn_conj = std::conj(cdn);
+    expect_near(dn_conj.value().real(), 1, tol);
+    expect_near(dn_conj.value().imag(), -1, tol);
+    expect_complex_nan_dualnumber(dn_conj);
 
-  DualNumber<std::complex<double>> cdn2{std::complex<double>{1., 1.}};
+    DualNumber<std::complex<double>> cdn2{std::complex<double>{1., 1.}};
 
-  DualNumber<double> dn_real2 = std::real(cdn2);
-  expect_near(dn_real2.value(), 1, tol);
-  expect_nan(dn_real2.derivatives());
+    DualNumber<double> dn_real2 = std::real(cdn2);
+    expect_near(dn_real2.value(), 1, tol);
+    expect_nan(dn_real2.derivatives());
 
-  DualNumber<double> dn_imag2 = std::imag(cdn2);
-  expect_near(dn_imag2.value(), 1, tol);
-  expect_nan(dn_imag2.derivatives());
+    DualNumber<double> dn_imag2 = std::imag(cdn2);
+    expect_near(dn_imag2.value(), 1, tol);
+    expect_nan(dn_imag2.derivatives());
 
-  DualNumber<double> dn_norm2 = std::norm(cdn2);
-  expect_near(dn_norm2.value(), 2, tol);
-  expect_nan(dn_norm2.derivatives());
+    DualNumber<double> dn_norm2 = std::norm(cdn2);
+    expect_near(dn_norm2.value(), 2, tol);
+    expect_nan(dn_norm2.derivatives());
 
-  DualNumber<double> dn_abs2 = std::abs(cdn2);
-  expect_near(dn_abs2.value(), sqrt2, tol);
-  expect_nan(dn_abs2.derivatives());
+    DualNumber<double> dn_abs2 = std::abs(cdn2);
+    expect_near(dn_abs2.value(), sqrt2, tol);
+    expect_nan(dn_abs2.derivatives());
 
-  DualNumber<std::complex<double>> dn_conj2 = std::conj(cdn2);
-  expect_near(dn_conj2.value().real(), 1, tol);
-  expect_near(dn_conj2.value().imag(), -1, tol);
-  expect_nan(dn_conj2.derivatives().real());
-  expect_nan(dn_conj2.derivatives().imag());
+    DualNumber<std::complex<double>> dn_conj2 = std::conj(cdn2);
+    expect_near(dn_conj2.value().real(), 1, tol);
+    expect_near(dn_conj2.value().imag(), -1, tol);
+    expect_nan(dn_conj2.derivatives().real());
+    expect_nan(dn_conj2.derivatives().imag());
+  }
 
-  DynamicSparseNumberArray<double, unsigned int> double_dsna;
-  double_dsna.resize(1);
-  double_dsna[0] = -1;
+  {
+    DynamicSparseNumberArray<double, unsigned int> double_dsna;
+    double_dsna.resize(1);
+    double_dsna[0] = -1;
 
-  DynamicSparseNumberArray<double, unsigned int> double_dsna_real = std::real(double_dsna);
-  expect_near(double_dsna_real[0], -1, tol);
-  DynamicSparseNumberArray<double, unsigned int> double_dsna_imag = std::imag(double_dsna);
-  expect_near(double_dsna_imag[0], 0, tol);
-  DynamicSparseNumberArray<double, unsigned int> double_dsna_norm = std::norm(double_dsna);
-  expect_near(double_dsna_norm[0], 1, tol);
+    DynamicSparseNumberArray<double, unsigned int> double_dsna_real = std::real(double_dsna);
+    expect_near(double_dsna_real[0], -1, tol);
+    DynamicSparseNumberArray<double, unsigned int> double_dsna_imag = std::imag(double_dsna);
+    expect_near(double_dsna_imag[0], 0, tol);
+    DynamicSparseNumberArray<double, unsigned int> double_dsna_norm = std::norm(double_dsna);
+    expect_near(double_dsna_norm[0], 1, tol);
 
-  DynamicSparseNumberArray<std::complex<double>, unsigned int> complex_dsna;
-  complex_dsna.resize(1);
-  complex_dsna[0].real(-1);
-  complex_dsna[0].imag(-1);
+    DynamicSparseNumberArray<std::complex<double>, unsigned int> complex_dsna;
+    complex_dsna.resize(1);
+    complex_dsna[0].real(-1);
+    complex_dsna[0].imag(-1);
 
-  DynamicSparseNumberArray<double, unsigned int> complex_dsna_real = std::real(complex_dsna);
-  expect_near(complex_dsna_real[0], -1, tol);
-  DynamicSparseNumberArray<double, unsigned int> complex_dsna_imag = std::imag(complex_dsna);
-  expect_near(complex_dsna_imag[0], -1, tol);
-  DynamicSparseNumberArray<double, unsigned int> complex_dsna_norm = std::norm(complex_dsna);
-  expect_near(complex_dsna_norm[0], 2, tol);
+    DynamicSparseNumberArray<double, unsigned int> complex_dsna_real = std::real(complex_dsna);
+    expect_near(complex_dsna_real[0], -1, tol);
+    DynamicSparseNumberArray<double, unsigned int> complex_dsna_imag = std::imag(complex_dsna);
+    expect_near(complex_dsna_imag[0], -1, tol);
+    DynamicSparseNumberArray<double, unsigned int> complex_dsna_norm = std::norm(complex_dsna);
+    expect_near(complex_dsna_norm[0], 2, tol);
+  }
+
+  // Ascertain that we can do operations between DualNumber<T> and DualNumber<std::complex<T>>
+
+  DualNumber<double>() * DualNumber<std::complex<double>>();
+  DualNumber<std::complex<double>>() * DualNumber<double>();
 
   return returnval;
 }


### PR DESCRIPTION
Previously we had CompareTypes defined for ops between
std::complex<U> and T where T != U, but not for T == U.
This remedies that