### PR TITLE
Add boolean to turn off derivative calculations

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -39,6 +39,7 @@ include_HEADERS += numerics/include/metaphysicl/dualdynamicsparsenumbervector.h
 include_HEADERS += numerics/include/metaphysicl/dualdynamicsparsenumbervector_decl.h
 include_HEADERS += numerics/include/metaphysicl/dualexpression.h
 include_HEADERS += numerics/include/metaphysicl/dualnamedarray.h
+include_HEADERS += numerics/include/metaphysicl/dualnumber_forward.h
 include_HEADERS += numerics/include/metaphysicl/dualnumber.h
 include_HEADERS += numerics/include/metaphysicl/dualnumber_decl.h
 include_HEADERS += numerics/include/metaphysicl/nddualnumber.h

--- a/src/numerics/include/metaphysicl/dualdynamicsparsenumberarray_decl.h
+++ b/src/numerics/include/metaphysicl/dualdynamicsparsenumberarray_decl.h
@@ -92,9 +92,9 @@ gradient(const DynamicSparseNumberArray<T, I>& a);
 // DualNumber is subordinate to DynamicSparseNumberArray
 
 #define DualDynamicSparseNumberArray_comparisons(templatename) \
-template<typename T, typename T2, typename D, typename I, bool reverseorder> \
-struct templatename<DynamicSparseNumberArray<T2, I>, DualNumber<T, D>, reverseorder> { \
-  typedef DynamicSparseNumberArray<typename Symmetric##templatename<T2,DualNumber<T, D>,reverseorder>::supertype, I> supertype; \
+template<typename T, typename T2, typename D, typename I, bool asd, bool reverseorder> \
+struct templatename<DynamicSparseNumberArray<T2, I>, DualNumber<T, D, asd>, reverseorder> { \
+  typedef DynamicSparseNumberArray<typename Symmetric##templatename<T2,DualNumber<T, D, asd>,reverseorder>::supertype, I> supertype; \
 }
 
 DualDynamicSparseNumberArray_comparisons(CompareTypes);

--- a/src/numerics/include/metaphysicl/dualdynamicsparsenumbervector_decl.h
+++ b/src/numerics/include/metaphysicl/dualdynamicsparsenumbervector_decl.h
@@ -92,9 +92,9 @@ gradient(const DynamicSparseNumberVector<T, I>& a);
 // DualNumber is subordinate to DynamicSparseNumberVector
 
 #define DualDynamicSparseNumberVector_comparisons(templatename) \
-template<typename T, typename T2, typename D, typename I, bool reverseorder> \
-struct templatename<DynamicSparseNumberVector<T2, I>, DualNumber<T, D>, reverseorder> { \
-  typedef DynamicSparseNumberVector<typename Symmetric##templatename<T2,DualNumber<T, D>,reverseorder>::supertype, I> supertype; \
+template<typename T, typename T2, typename D, typename I, bool asd, bool reverseorder> \
+struct templatename<DynamicSparseNumberVector<T2, I>, DualNumber<T, D, asd>, reverseorder> { \
+  typedef DynamicSparseNumberVector<typename Symmetric##templatename<T2,DualNumber<T, D, asd>,reverseorder>::supertype, I> supertype; \
 }
 
 DualDynamicSparseNumberVector_comparisons(CompareTypes);

--- a/src/numerics/include/metaphysicl/dualnumber.h
+++ b/src/numerics/include/metaphysicl/dualnumber.h
@@ -38,185 +38,182 @@ template <typename T, typename D>
 class NotADuckDualNumber;
 
 // static member initialization
-template <typename T, typename D>
-bool DualNumber<T,D>::do_derivatives = true;
+template <typename T, typename D, bool asd>
+bool DualNumber<T,D,asd>::do_derivatives = true;
 
 // Member definitions
-template <typename T, typename D>
+template <typename T, typename D, bool asd>
 inline
 T&
-DualNumber<T,D>::value() { return _val; }
+DualNumber<T,D,asd>::value() { return _val; }
 
-template <typename T, typename D>
+template <typename T, typename D, bool asd>
 inline
 const T&
-DualNumber<T,D>::value() const { return _val; }
+DualNumber<T,D,asd>::value() const { return _val; }
 
-template <typename T, typename D>
+template <typename T, typename D, bool asd>
 inline
 D&
-DualNumber<T,D>::derivatives() { return _deriv; }
+DualNumber<T,D,asd>::derivatives() { return _deriv; }
 
-template <typename T, typename D>
+template <typename T, typename D, bool asd>
 inline
 const D&
-DualNumber<T,D>::derivatives() const { return _deriv; }
+DualNumber<T,D,asd>::derivatives() const { return _deriv; }
 
-template <typename T, typename D>
+template <typename T, typename D, bool asd>
 inline
 bool
-DualNumber<T,D>::boolean_test() const { return _val; }
+DualNumber<T,D,asd>::boolean_test() const { return _val; }
 
-template <typename T, typename D>
+template <typename T, typename D, bool asd>
 inline
-DualNumber<T,D>
-DualNumber<T,D>::operator- () const { return DualNumber<T,D>(-_val, -_deriv); }
+DualNumber<T,D,asd>
+DualNumber<T,D,asd>::operator- () const { return DualNumber<T,D,asd>(-_val, -_deriv); }
 
-template <typename T, typename D>
+template <typename T, typename D, bool asd>
 inline
-DualNumber<T,D>
-DualNumber<T,D>::operator! () const { return DualNumber<T,D>(!_val, !_deriv); }
+DualNumber<T,D,asd>
+DualNumber<T,D,asd>::operator! () const { return DualNumber<T,D,asd>(!_val, !_deriv); }
 
-template <typename T, typename D>
+template <typename T, typename D, bool asd>
 template <typename T2, typename D2>
 inline
-DualNumber<T,D> &
-DualNumber<T,D>::operator=(const DualNumber<T2,D2> & dn)
+DualNumber<T,D,asd> &
+DualNumber<T,D,asd>::operator=(const DualNumber<T2,D2,asd> & dn)
 {
   _val = dn.value();
 
-  if (!do_derivatives)
-    return *this;
-  _deriv = dn.derivatives();
+  if (!allow_skipping_derivatives || do_derivatives)
+    _deriv = dn.derivatives();
+
   return *this;
 }
 
-template <typename T, typename D>
+template <typename T, typename D, bool asd>
 inline
-DualNumber<T,D> &
-DualNumber<T,D>::operator=(const DualNumber<T,D> & dn)
+DualNumber<T,D,asd> &
+DualNumber<T,D,asd>::operator=(const DualNumber<T,D,asd> & dn)
 {
   _val = dn.value();
 
-  if (!do_derivatives)
-    return *this;
-  _deriv = dn.derivatives();
+  if (!allow_skipping_derivatives || do_derivatives)
+    _deriv = dn.derivatives();
+
   return *this;
 }
 
-template <typename T, typename D>
+template <typename T, typename D, bool asd>
 inline
-DualNumber<T,D> &
-DualNumber<T,D>::operator=(DualNumber<T,D> && dn)
+DualNumber<T,D,asd> &
+DualNumber<T,D,asd>::operator=(DualNumber<T,D,asd> && dn)
 {
   _val = std::move(dn.value());
 
-  if (!do_derivatives)
-    return *this;
-  _deriv = std::move(dn.derivatives());
+  if (!allow_skipping_derivatives || do_derivatives)
+    _deriv = std::move(dn.derivatives());
+
   return *this;
 }
 
-template <typename T, typename D>
+template <typename T, typename D, bool asd>
 template <typename T2, typename D2>
 inline
-DualNumber<T,D> &
-DualNumber<T,D>::operator=(const NotADuckDualNumber<T2,D2> & nd_dn)
+DualNumber<T,D,asd> &
+DualNumber<T,D,asd>::operator=(const NotADuckDualNumber<T2,D2> & nd_dn)
 {
   _val = nd_dn.value();
 
-  if (!do_derivatives)
-    return *this;
-  _deriv = nd_dn.derivatives();
+  if (!allow_skipping_derivatives || do_derivatives)
+    _deriv = nd_dn.derivatives();
+
   return *this;
 }
 
-template <typename T, typename D>
+template <typename T, typename D, bool asd>
 inline
-DualNumber<T,D>::DualNumber(const DualNumber<T,D> & dn) :
+DualNumber<T,D,asd>::DualNumber(const DualNumber<T,D,asd> & dn) :
     _val(dn.value())
 {
-  if (!do_derivatives)
-    return;
-
-  _deriv = dn.derivatives();
+  if (!allow_skipping_derivatives || do_derivatives)
+    _deriv = dn.derivatives();
 }
 
-template <typename T, typename D>
+template <typename T, typename D, bool asd>
 inline
-DualNumber<T,D>::DualNumber(DualNumber<T,D> && dn) :
+DualNumber<T,D,asd>::DualNumber(DualNumber<T,D,asd> && dn) :
     _val(std::move(dn.value()))
 {
-  if (!do_derivatives)
-    return;
-
-  _deriv = std::move(dn.derivatives());
+  if (!allow_skipping_derivatives || do_derivatives)
+    _deriv = std::move(dn.derivatives());
 }
 
-template <typename T, typename D>
+template <typename T, typename D, bool asd>
 template <typename T2, typename D2>
 inline
-DualNumber<T,D>::DualNumber(const DualNumberSurrogate<T2,D2> & dns) :
+DualNumber<T,D,asd>::DualNumber(const DualNumberSurrogate<T2,D2> & dns) :
     _val(dns.value())
 {
-  if (!do_derivatives)
-    return;
-  auto size = dns.derivatives().size();
-  for (decltype(size) i = 0; i < size; ++i)
-    _deriv[i] = *dns.derivatives()[i];
+  if (!allow_skipping_derivatives || do_derivatives)
+  {
+    auto size = dns.derivatives().size();
+    for (decltype(size) i = 0; i < size; ++i)
+      _deriv[i] = *dns.derivatives()[i];
+  }
 }
 
-template <typename T, typename D>
+template <typename T, typename D, bool asd>
 template <typename T2, typename D2>
 inline
-DualNumber<T,D> &
-DualNumber<T,D>::operator=(const DualNumberSurrogate<T2,D2> & dns)
+DualNumber<T,D,asd> &
+DualNumber<T,D,asd>::operator=(const DualNumberSurrogate<T2,D2> & dns)
 {
   _val = dns.value();
 
-  if (!do_derivatives)
-    return *this;
-  auto size = dns.derivatives().size();
-  for (decltype(size) i = 0; i < size; ++i)
-    _deriv[i] = *dns.derivatives()[i];
+  if (!allow_skipping_derivatives || do_derivatives)
+  {
+    auto size = dns.derivatives().size();
+    for (decltype(size) i = 0; i < size; ++i)
+      _deriv[i] = *dns.derivatives()[i];
+  }
   return *this;
 }
 
-template <typename T, typename D>
+template <typename T, typename D, bool asd>
 template <typename T2>
 inline
-DualNumber<T,D> &
-DualNumber<T,D>::operator=(const T2 & scalar)
+DualNumber<T,D,asd> &
+DualNumber<T,D,asd>::operator=(const T2 & scalar)
 {
   _val = scalar;
-  if (!do_derivatives)
-    return *this;
-  _deriv = 0;
+  if (!allow_skipping_derivatives || do_derivatives)
+    _deriv = 0;
   return *this;
 }
 
 //
 // Member function definitions
 //
-template <typename T, typename D>
+template <typename T, typename D, bool asd>
 template <typename T2>
 inline
-DualNumber<T,D>::DualNumber(const T2& val) :
-  _val  (DualNumberConstructor<T,D>::value(val))
+DualNumber<T,D,asd>::DualNumber(const T2& val) :
+    _val  (DualNumberConstructor<T,D,asd>::value(val))
 {
-  if (do_derivatives)
-    _deriv = DualNumberConstructor<T,D>::deriv(val);
+  if (!allow_skipping_derivatives || do_derivatives)
+    _deriv = DualNumberConstructor<T,D,asd>::deriv(val);
 }
 
-template <typename T, typename D>
+template <typename T, typename D, bool asd>
 template <typename T2, typename D2>
 inline
-DualNumber<T,D>::DualNumber(const T2& val,
+DualNumber<T,D,asd>::DualNumber(const T2& val,
                             const D2& deriv) :
-  _val  (DualNumberConstructor<T,D>::value(val,deriv))
+  _val  (DualNumberConstructor<T,D,asd>::value(val,deriv))
 {
-  if (do_derivatives)
-    _deriv = DualNumberConstructor<T,D>::deriv(val,deriv);
+  if (!allow_skipping_derivatives || do_derivatives)
+    _deriv = DualNumberConstructor<T,D,asd>::deriv(val,deriv);
 }
 
 // Some helpers for reducing temporary creation and memset, memcpy calls
@@ -226,13 +223,15 @@ template <typename T,
           class D,
           std::size_t N,
           typename DT,
+          bool asd,
           typename std::enable_if<ScalarTraits<T>::value, int>::type = 0>
 inline void
-derivative_multiply_helper(DualNumber<T, D<N, DT>> & out, const DualNumber<T, D<N, DT>> & in)
+derivative_multiply_helper(DualNumber<T, D<N, DT>, asd> & out, const DualNumber<T, D<N, DT>, asd> & in)
 {
   // do_derivatives is a static member so only need to check one object
-  if (!out.do_derivatives)
+  if (asd && !out.do_derivatives)
     return;
+
   auto & din = in.derivatives();
   auto & dout = out.derivatives();
   const auto vin = in.value();
@@ -242,13 +241,14 @@ derivative_multiply_helper(DualNumber<T, D<N, DT>> & out, const DualNumber<T, D<
     dout[i] = vin * dout[i] + vout * din[i];
 }
 
-template <typename T, typename D>
+template <typename T, typename D, bool asd>
 inline void
-derivative_multiply_helper(DualNumber<T, D> & out, const DualNumber<T, D> & in)
+derivative_multiply_helper(DualNumber<T, D, asd> & out, const DualNumber<T, D, asd> & in)
 {
   // do_derivatives is a static member so only need to check one object
-  if (!out.do_derivatives)
+  if (asd && !out.do_derivatives)
     return;
+
   if (&in == &out)
     out.derivatives() = out.derivatives() * in.value() + out.value() * in.derivatives();
   else
@@ -258,13 +258,14 @@ derivative_multiply_helper(DualNumber<T, D> & out, const DualNumber<T, D> & in)
   }
 }
 
-template <typename T, typename D, typename T2, typename D2>
+template <typename T, typename D, typename T2, typename D2, bool asd>
 inline void
-derivative_multiply_helper(DualNumber<T, D> & out, const DualNumber<T2, D2> & in)
+derivative_multiply_helper(DualNumber<T, D, asd> & out, const DualNumber<T2, D2, asd> & in)
 {
   // Potentially different classes so need to check both
-  if (!(out.do_derivatives || in.do_derivatives))
+  if (asd && !(out.do_derivatives || in.do_derivatives))
     return;
+
   out.derivatives() *= in.value();
   out.derivatives() += out.value() * in.derivatives();
 }
@@ -274,12 +275,13 @@ template <typename T,
           class D,
           std::size_t N,
           typename DT,
+          bool asd,
           typename std::enable_if<ScalarTraits<T>::value, int>::type = 0>
 inline void
-derivative_division_helper(DualNumber<T, D<N, DT>> & out, const DualNumber<T, D<N, DT>> & in)
+derivative_division_helper(DualNumber<T, D<N, DT>, asd> & out, const DualNumber<T, D<N, DT>, asd> & in)
 {
   // do_derivatives is a static member so only need to check one object
-  if (!out.do_derivatives)
+  if (asd && !out.do_derivatives)
     return;
   auto & din = in.derivatives();
   auto & dout = out.derivatives();
@@ -290,13 +292,14 @@ derivative_division_helper(DualNumber<T, D<N, DT>> & out, const DualNumber<T, D<
     dout[i] = dout[i] / vin - din[i] * vout / (vin * vin);
 }
 
-template <typename T, typename D>
+template <typename T, typename D, bool asd>
 inline void
-derivative_division_helper(DualNumber<T, D> & out, const DualNumber<T, D> & in)
+derivative_division_helper(DualNumber<T, D, asd> & out, const DualNumber<T, D, asd> & in)
 {
   // do_derivatives is a static member so only need to check one object
-  if (!out.do_derivatives)
+  if (asd && !out.do_derivatives)
     return;
+
   if (&in == &out)
     out.derivatives() =
       out.derivatives() / in.value() - out.value() / (in.value() * in.value()) * in.derivatives();
@@ -307,12 +310,12 @@ derivative_division_helper(DualNumber<T, D> & out, const DualNumber<T, D> & in)
   }
 }
 
-template <typename T, typename D, typename T2, typename D2>
+template <typename T, typename D, typename T2, typename D2, bool asd>
 inline void
-derivative_division_helper(DualNumber<T, D> & out, const DualNumber<T2, D2> & in)
+derivative_division_helper(DualNumber<T, D, asd> & out, const DualNumber<T2, D2, asd> & in)
 {
   // Potentially different classes so need to check both
-  if (!(out.do_derivatives || in.do_derivatives))
+  if (asd && !(out.do_derivatives || in.do_derivatives))
     return;
   out.derivatives() /= in.value();
   out.derivatives() -= out.value()/(in.value()*in.value()) * in.derivatives();
@@ -327,13 +330,13 @@ derivative_division_helper(DualNumber<T, D> & out, const DualNumber<T2, D2> & in
 // errors.
 
 #define DualNumber_preop(opname, functorname, simplecalc, dualcalc) \
-template <typename T, typename D> \
+template <typename T, typename D, bool asd> \
 template <typename T2> \
 inline \
-DualNumber<T,D>& \
-DualNumber<T,D>::operator opname##= (const T2& in) \
+DualNumber<T,D,asd>& \
+DualNumber<T,D,asd>::operator opname##= (const T2& in) \
 { \
-  if (do_derivatives) \
+  if (!allow_skipping_derivatives || do_derivatives) \
   { \
     simplecalc; \
   } \
@@ -341,13 +344,13 @@ DualNumber<T,D>::operator opname##= (const T2& in) \
   return *this; \
 } \
  \
-template <typename T, typename D> \
+template <typename T, typename D, bool asd> \
 template <typename T2, typename D2> \
 inline \
-DualNumber<T,D>& \
-DualNumber<T,D>::operator opname##= (const DualNumber<T2,D2>& in) \
+DualNumber<T,D,asd>& \
+DualNumber<T,D,asd>::operator opname##= (const DualNumber<T2,D2,asd>& in) \
 { \
-  if (do_derivatives) \
+  if (!allow_skipping_derivatives || do_derivatives) \
   { \
     dualcalc; \
   } \
@@ -355,13 +358,13 @@ DualNumber<T,D>::operator opname##= (const DualNumber<T2,D2>& in) \
   return *this; \
 } \
  \
-template <typename T, typename D> \
+template <typename T, typename D, bool asd> \
 template <typename T2, typename D2> \
 inline \
-DualNumber<T,D> & \
-DualNumber<T,D>::operator opname##= (const NotADuckDualNumber<T2,D2>& in) \
+DualNumber<T,D,asd> & \
+DualNumber<T,D,asd>::operator opname##= (const NotADuckDualNumber<T2,D2>& in) \
 { \
-  if (do_derivatives) \
+  if (!allow_skipping_derivatives || do_derivatives) \
   { \
     dualcalc; \
   } \
@@ -369,38 +372,38 @@ DualNumber<T,D>::operator opname##= (const NotADuckDualNumber<T2,D2>& in) \
   return *this; \
 } \
  \
-template <typename T, typename D, typename T2, typename D2> \
+template <typename T, typename D, typename T2, typename D2, bool asd> \
 inline \
-typename functorname##Type<DualNumber<T,D>,DualNumber<T2,D2> >::supertype \
-operator opname (const DualNumber<T,D>& a, const DualNumber<T2,D2>& b) \
+typename functorname##Type<DualNumber<T,D,asd>,DualNumber<T2,D2,asd> >::supertype \
+operator opname (const DualNumber<T,D,asd>& a, const DualNumber<T2,D2,asd>& b) \
 { \
   typedef typename \
-    functorname##Type<DualNumber<T,D>,DualNumber<T2,D2> >::supertype \
+    functorname##Type<DualNumber<T,D,asd>,DualNumber<T2,D2,asd> >::supertype \
     DS; \
   DS returnval = a; \
   returnval opname##= b; \
   return returnval; \
 } \
  \
-template <typename T, typename T2, typename D> \
+template <typename T, typename T2, typename D, bool asd> \
 inline \
-typename functorname##Type<DualNumber<T2,D>,T,true>::supertype \
-operator opname (const T& a, const DualNumber<T2,D>& b) \
+typename functorname##Type<DualNumber<T2,D,asd>,T,true>::supertype \
+operator opname (const T& a, const DualNumber<T2,D,asd>& b) \
 { \
   typedef typename \
-    functorname##Type<DualNumber<T2,D>,T,true>::supertype DS; \
+    functorname##Type<DualNumber<T2,D,asd>,T,true>::supertype DS; \
   DS returnval = a; \
   returnval opname##= b; \
   return returnval; \
 } \
  \
-template <typename T, typename D, typename T2> \
+template <typename T, typename D, typename T2, bool asd> \
 inline \
-typename functorname##Type<DualNumber<T,D>,T2,false>::supertype \
-operator opname (const DualNumber<T,D>& a, const T2& b) \
+typename functorname##Type<DualNumber<T,D,asd>,T2,false>::supertype \
+operator opname (const DualNumber<T,D,asd>& a, const T2& b) \
 { \
   typedef typename \
-    functorname##Type<DualNumber<T,D>,T2,false>::supertype DS; \
+    functorname##Type<DualNumber<T,D,asd>,T2,false>::supertype DS; \
   DS returnval = a; \
   returnval opname##= b; \
   return returnval; \
@@ -415,26 +418,26 @@ operator opname (const DualNumber<T,D>& a, const T2& b) \
 #define DualNumber_op(opname, functorname, simplecalc, dualcalc) \
         DualNumber_preop(opname, functorname, simplecalc, dualcalc) \
  \
-template <typename T, typename D, typename T2, typename D2> \
+template <typename T, typename D, typename T2, typename D2, bool asd> \
 inline \
-typename functorname##Type<DualNumber<T,D>,DualNumber<T2,D2> >::supertype \
-operator opname (DualNumber<T,D>&& a, const DualNumber<T2,D2>& b) \
+typename functorname##Type<DualNumber<T,D,asd>,DualNumber<T2,D2,asd> >::supertype \
+operator opname (DualNumber<T,D,asd>&& a, const DualNumber<T2,D2,asd>& b) \
 { \
   typedef typename \
-    functorname##Type<DualNumber<T,D>,DualNumber<T2,D2> >::supertype \
+    functorname##Type<DualNumber<T,D,asd>,DualNumber<T2,D2,asd> >::supertype \
     DS; \
   DS returnval = std::move(a); \
   returnval opname##= b; \
   return returnval; \
 } \
  \
-template <typename T, typename D, typename T2> \
+template <typename T, typename D, typename T2, bool asd> \
 inline \
-typename functorname##Type<DualNumber<T,D>,T2,false>::supertype \
-operator opname (DualNumber<T,D>&& a, const T2& b) \
+typename functorname##Type<DualNumber<T,D,asd>,T2,false>::supertype \
+operator opname (DualNumber<T,D,asd>&& a, const T2& b) \
 { \
   typedef typename \
-    functorname##Type<DualNumber<T,D>,T2,false>::supertype DS; \
+    functorname##Type<DualNumber<T,D,asd>,T2,false>::supertype DS; \
   DS returnval = std::move(a); \
   returnval opname##= b; \
   return returnval; \
@@ -461,50 +464,56 @@ DualNumber_op(/,
 
 
 #define DualNumber_compare(opname)                          \
-template <typename T, typename D, typename T2, typename D2> \
+template <typename T, typename D, typename T2, typename D2, bool asd> \
 inline \
 bool \
-operator opname  (const DualNumber<T,D>& a, const DualNumber<T2,D2>& b) \
+operator opname  (const DualNumber<T,D,asd>& a, const DualNumber<T2,D2,asd>& b) \
 { \
   return (a.value() opname b.value()); \
 } \
  \
-template <typename T, typename T2, typename D2> \
+template <typename T, typename T2, typename D2, bool asd> \
 inline \
 typename boostcopy::enable_if_class< \
-  typename CompareTypes<DualNumber<T2,D2>,T>::supertype, \
+  typename CompareTypes<DualNumber<T2,D2,asd>,T>::supertype, \
   bool \
 >::type \
-operator opname  (const T& a, const DualNumber<T2,D2>& b) \
+operator opname  (const T& a, const DualNumber<T2,D2,asd>& b) \
 { \
   return (a opname b.value()); \
 } \
  \
-template <typename T, typename T2, typename D> \
+template <typename T, typename T2, typename D, bool asd> \
 inline \
 typename boostcopy::enable_if_class< \
-  typename CompareTypes<DualNumber<T,D>,T2>::supertype, \
+  typename CompareTypes<DualNumber<T,D,asd>,T2>::supertype, \
   bool \
 >::type \
-operator opname  (const DualNumber<T,D>& a, const T2& b) \
+operator opname  (const DualNumber<T,D,asd>& a, const T2& b) \
 { \
   return (a.value() opname b); \
 }
 
-    DualNumber_compare(>) DualNumber_compare(>=) DualNumber_compare(<) DualNumber_compare(<=)
-        DualNumber_compare(==) DualNumber_compare(!=) DualNumber_compare(&&) DualNumber_compare(||)
+DualNumber_compare(>)
+DualNumber_compare(>=)
+DualNumber_compare(<)
+DualNumber_compare(<=)
+DualNumber_compare(==)
+DualNumber_compare(!=)
+DualNumber_compare(&&)
+DualNumber_compare(||)
 
-            template <typename T, typename D>
-            inline std::ostream &
-            operator<<(std::ostream & output, const DualNumber<T, D> & a)
+template <typename T, typename D, bool asd>
+inline std::ostream &
+operator<<(std::ostream & output, const DualNumber<T, D, asd> & a)
 {
   return output << '(' << a.value() << ',' << a.derivatives() << ')';
 }
 
 
-template <typename T, typename D>
+template <typename T, typename D, bool asd>
 inline
-D gradient(const DualNumber<T, D>& a)
+D gradient(const DualNumber<T, D, asd>& a)
 {
   return a.derivatives();
 }
@@ -516,8 +525,8 @@ namespace std {
 using MetaPhysicL::DualNumber;
 using MetaPhysicL::CompareTypes;
 
-template <typename T, typename D>
-inline bool isnan (const DualNumber<T,D> & a)
+template <typename T, typename D, bool asd>
+inline bool isnan (const DualNumber<T,D,asd> & a)
 {
   using std::isnan;
   return isnan(a.value());
@@ -526,13 +535,13 @@ inline bool isnan (const DualNumber<T,D> & a)
 
 #if __cplusplus >= 201103L
 #define DualNumber_std_unary(funcname, derivative, precalc) \
-template <typename T, typename D> \
+template <typename T, typename D, bool asd> \
 inline \
-DualNumber<T,D> funcname (const DualNumber<T,D> & in) \
+DualNumber<T,D,asd> funcname (const DualNumber<T,D,asd> & in) \
 { \
-  DualNumber<T,D> returnval = in; \
+  DualNumber<T,D,asd> returnval = in; \
   T funcval = std::funcname(in.value()); \
-  if (in.do_derivatives) \
+  if (!asd || in.do_derivatives) \
   { \
     precalc; \
     returnval.derivatives() *= derivative; \
@@ -541,12 +550,12 @@ DualNumber<T,D> funcname (const DualNumber<T,D> & in) \
   return returnval; \
 } \
  \
-template <typename T, typename D> \
+template <typename T, typename D, bool asd> \
 inline \
-DualNumber<T,D> funcname (DualNumber<T,D> && in) \
+DualNumber<T,D,asd> funcname (DualNumber<T,D,asd> && in) \
 { \
   T funcval = std::funcname(in.value()); \
-  if (in.do_derivatives) \
+  if (!asd || in.do_derivatives) \
   { \
     precalc; \
     in.derivatives() *= derivative; \
@@ -556,16 +565,16 @@ DualNumber<T,D> funcname (DualNumber<T,D> && in) \
 }
 
 #define DualNumber_equiv_unary(funcname, equivalent) \
-template <typename T, typename D> \
+template <typename T, typename D, bool asd> \
 inline \
-DualNumber<T,D> funcname (const DualNumber<T,D> & in) \
+DualNumber<T,D,asd> funcname (const DualNumber<T,D,asd> & in) \
 { \
   return std::equivalent(in); \
 } \
  \
-template <typename T, typename D> \
+template <typename T, typename D, bool asd> \
 inline \
-DualNumber<T,D> funcname (DualNumber<T,D> && in) \
+DualNumber<T,D,asd> funcname (DualNumber<T,D,asd> && in) \
 { \
   return std::equivalent(in); \
 }
@@ -573,12 +582,12 @@ DualNumber<T,D> funcname (DualNumber<T,D> && in) \
 #else
 
 #define DualNumber_std_unary(funcname, derivative, precalc) \
-template <typename T, typename D> \
+template <typename T, typename D, bool asd> \
 inline \
-DualNumber<T,D> funcname (DualNumber<T,D> in) \
+DualNumber<T,D,asd> funcname (DualNumber<T,D,asd> in) \
 { \
   T funcval = std::funcname(in.value()); \
-  if (in.do_derivatives) \
+  if (!asd || in.do_derivatives) \
   { \
     precalc; \
     in.derivatives() *= derivative; \
@@ -588,9 +597,9 @@ DualNumber<T,D> funcname (DualNumber<T,D> in) \
 }
 
 #define DualNumber_equiv_unary(funcname, equivalent) \
-template <typename T, typename D> \
+template <typename T, typename D, bool asd> \
 inline \
-DualNumber<T,D> funcname (DualNumber<T,D> in) \
+DualNumber<T,D,asd> funcname (DualNumber<T,D,asd> in) \
 { \
   return std::equivalent(in); \
 }
@@ -673,15 +682,15 @@ DualNumber_equivfl_unary(rint)
 #endif // __cplusplus >= 201103L
 
 #define DualNumber_complex_std_unary_real(funcname) \
-template <typename T, typename D> \
-inline DualNumber<T, typename D::template rebind<T>::other> \
-funcname(const DualNumber<std::complex<T>, D> & in) \
+template <typename T, typename D, bool asd> \
+inline DualNumber<T, typename D::template rebind<T>::other, asd> \
+funcname(const DualNumber<std::complex<T>, D, asd> & in) \
 { \
   return {std::funcname(in.value()), std::numeric_limits<double>::quiet_NaN()}; \
 } \
-template <typename T> \
-inline DualNumber<T> \
-funcname(const DualNumber<std::complex<T>> & in)    \
+template <typename T, bool asd> \
+inline DualNumber<T,T,asd> \
+funcname(const DualNumber<std::complex<T>,std::complex<T>,asd> & in)    \
 { \
   return {std::funcname(in.value()), std::numeric_limits<double>::quiet_NaN()}; \
 }
@@ -692,16 +701,16 @@ DualNumber_complex_std_unary_real(norm)
 DualNumber_complex_std_unary_real(abs)
 
 #define DualNumber_complex_std_unary_complex_pre(funcname) \
-template <typename T, typename D> \
-inline DualNumber<std::complex<T>, D> \
-funcname(const DualNumber<std::complex<T>, D> & in) \
+template <typename T, typename D, bool asd> \
+inline DualNumber<std::complex<T>, D, asd> \
+funcname(const DualNumber<std::complex<T>, D, asd> & in) \
 { \
   return {std::funcname(in.value()), std::complex<T>{std::numeric_limits<double>::quiet_NaN(), \
                                                      std::numeric_limits<double>::quiet_NaN()}}; \
 } \
-template <typename T> \
-inline DualNumber<std::complex<T>> \
-funcname(const DualNumber<std::complex<T>> & in) \
+template <typename T, bool asd> \
+inline DualNumber<std::complex<T>,std::complex<T>,asd> \
+funcname(const DualNumber<std::complex<T>,std::complex<T>,asd> & in) \
 { \
   return {std::funcname(in.value()), std::complex<T>{std::numeric_limits<double>::quiet_NaN(), \
                                                      std::numeric_limits<double>::quiet_NaN()}}; \
@@ -710,18 +719,18 @@ funcname(const DualNumber<std::complex<T>> & in) \
 #if __cplusplus >= 201103L
 #define DualNumber_complex_std_unary_complex(funcname) \
 DualNumber_complex_std_unary_complex_pre(funcname) \
-template <typename T, typename D> \
-inline DualNumber<std::complex<T>, D> \
-funcname(DualNumber<std::complex<T>, D> && in) \
+template <typename T, typename D, bool asd> \
+inline DualNumber<std::complex<T>, D, asd> \
+funcname(DualNumber<std::complex<T>, D, asd> && in) \
 { \
   in.value() = std::funcname(in.value()); \
   in.derivatives() = std::complex<T>(std::numeric_limits<double>::quiet_NaN(), \
                                      std::numeric_limits<double>::quiet_NaN()); \
   return in; \
 } \
-template <typename T> \
-inline DualNumber<std::complex<T>> \
-funcname(DualNumber<std::complex<T>> && in) \
+template <typename T, bool asd> \
+inline DualNumber<std::complex<T>,std::complex<T>,asd> \
+funcname(DualNumber<std::complex<T>,std::complex<T>,asd> && in) \
 { \
   in.value() = std::funcname(in.value()); \
   in.derivatives() = std::complex<T>(std::numeric_limits<double>::quiet_NaN(), \
@@ -736,80 +745,82 @@ DualNumber_complex_std_unary_complex_pre(funcname)
 DualNumber_complex_std_unary_complex(conj)
 
 #define DualNumber_std_binary(funcname, derivative) \
-template <typename T, typename D, typename T2, typename D2> \
+template <typename T, typename D, typename T2, typename D2, bool asd> \
 inline \
-typename CompareTypes<DualNumber<T,D>,DualNumber<T2,D2> >::supertype \
-funcname (const DualNumber<T,D>& a, const DualNumber<T2,D2>& b) \
+typename CompareTypes<DualNumber<T,D,asd>,DualNumber<T2,D2,asd> >::supertype \
+funcname (const DualNumber<T,D,asd>& a, const DualNumber<T2,D2,asd>& b) \
 { \
   typedef typename CompareTypes<T,T2>::supertype TS; \
-  typedef typename CompareTypes<DualNumber<T,D>,DualNumber<T2,D2> >::supertype type; \
+  typedef typename CompareTypes<DualNumber<T,D,asd>,DualNumber<T2,D2,asd> >::supertype type; \
  \
   TS funcval = std::funcname(a.value(), b.value()); \
-  if (!(a.do_derivatives || b.do_derivatives)) \
+  if (asd && !(a.do_derivatives || b.do_derivatives)) \
     return type(funcval, 0); \
-  return type(funcval, derivative); \
+  else \
+    return type(funcval, derivative); \
 } \
  \
-template <typename T, typename D> \
+template <typename T, typename D, bool asd> \
 inline \
-DualNumber<T,D> \
-funcname (const DualNumber<T,D>& a, const DualNumber<T,D>& b) \
+DualNumber<T,D,asd> \
+funcname (const DualNumber<T,D,asd>& a, const DualNumber<T,D,asd>& b) \
 { \
   T funcval = std::funcname(a.value(), b.value()); \
-  if (!a.do_derivatives) \
-    return DualNumber<T,D>(funcval, 0); \
-  return DualNumber<T,D>(funcval, derivative); \
+  if (asd && !a.do_derivatives) \
+    return DualNumber<T,D,asd>(funcval, 0); \
+  else \
+    return DualNumber<T,D,asd>(funcval, derivative); \
 } \
  \
-template <typename T, typename T2, typename D> \
+template <typename T, typename T2, typename D, bool asd> \
 inline \
-typename CompareTypes<DualNumber<T2,D>,T,true>::supertype \
-funcname (const T& a, const DualNumber<T2,D>& b) \
+typename CompareTypes<DualNumber<T2,D,asd>,T,true>::supertype \
+funcname (const T& a, const DualNumber<T2,D,asd>& b) \
 { \
-  typedef typename CompareTypes<DualNumber<T2,D>,T,true>::supertype type; \
+  typedef typename CompareTypes<DualNumber<T2,D,asd>,T,true>::supertype type; \
   type newa(a); \
   return std::funcname(newa, b); \
 } \
  \
-template <typename T, typename T2, typename D> \
+template <typename T, typename T2, typename D, bool asd> \
 inline \
-typename CompareTypes<DualNumber<T,D>,T2>::supertype \
-funcname (const DualNumber<T,D>& a, const T2& b) \
+typename CompareTypes<DualNumber<T,D,asd>,T2>::supertype \
+funcname (const DualNumber<T,D,asd>& a, const T2& b) \
 { \
-  typedef typename CompareTypes<DualNumber<T,D>,T2>::supertype type; \
+  typedef typename CompareTypes<DualNumber<T,D,asd>,T2>::supertype type; \
   type newb(b); \
   return std::funcname(a, newb); \
 }
 
 #define DualNumber_equiv_binary(funcname, equivalent) \
-template <typename T, typename D, typename T2, typename D2> \
+template <typename T, typename D, typename T2, typename D2, bool asd> \
 inline \
-typename CompareTypes<DualNumber<T,D>,DualNumber<T2,D2> >::supertype \
-funcname (const DualNumber<T,D>& a, const DualNumber<T2,D2>& b) \
+typename CompareTypes<DualNumber<T,D,asd>,DualNumber<T2,D2,asd> >::supertype \
+funcname (const DualNumber<T,D,asd>& a, const DualNumber<T2,D2,asd>& b) \
 { \
   return std::equivalent(a,b); \
 } \
  \
-template <typename T, typename D> \
+template <typename T, typename D, bool asd> \
 inline \
-DualNumber<T,D> \
-funcname (const DualNumber<T,D>& a, const DualNumber<T,D>& b) \
+DualNumber<T,D,asd> \
+funcname (const DualNumber<T,D,asd>& a, const DualNumber<T,D,asd>& b) \
 { \
   return std::equivalent(a,b); \
 } \
  \
-template <typename T, typename T2, typename D> \
+template <typename T, typename T2, typename D, bool asd> \
 inline \
-typename CompareTypes<DualNumber<T2,D>,T,true>::supertype \
-funcname (const T& a, const DualNumber<T2,D>& b) \
+typename CompareTypes<DualNumber<T2,D,asd>,T,true>::supertype \
+funcname (const T& a, const DualNumber<T2,D,asd>& b) \
 { \
   return std::equivalent(a,b); \
 } \
  \
-template <typename T, typename T2, typename D> \
+template <typename T, typename T2, typename D, bool asd> \
 inline \
-typename CompareTypes<DualNumber<T,D>,T2>::supertype \
-funcname (const DualNumber<T,D>& a, const T2& b) \
+typename CompareTypes<DualNumber<T,D,asd>,T2>::supertype \
+funcname (const DualNumber<T,D,asd>& a, const T2& b) \
 { \
   return std::equivalent(a,b); \
 }

--- a/src/numerics/include/metaphysicl/dualnumber_decl.h
+++ b/src/numerics/include/metaphysicl/dualnumber_decl.h
@@ -36,6 +36,7 @@
 #include "metaphysicl/dualderivatives.h"
 #include "metaphysicl/raw_type.h"
 #include "metaphysicl/testable.h"
+#include "metaphysicl/dualnumber_forward.h"
 
 namespace MetaPhysicL {
 
@@ -44,13 +45,23 @@ class NotADuckDualNumber;
 template <typename T, typename D>
 class DualNumberSurrogate;
 
-template <typename T, typename D=T>
-class DualNumber : public safe_bool<DualNumber<T,D> >
+/**
+ * \p T denotes the type of the value
+ * \p D denotes the derivative type. This may be a builtin or it could be a container
+ * \p asd is short for allow_skipping_derivatives, e.g. at compile time a user may
+ *    choose whether the do_derivatives static member can influence the computation
+ *    of derivatives
+ */
+template <typename T, typename D, bool asd>
+class DualNumber : public safe_bool<DualNumber<T,D,asd> >
 {
 public:
   typedef T value_type;
 
   typedef D derivatives_type;
+
+  // allow clearer code
+  static constexpr bool allow_skipping_derivatives = asd;
 
   DualNumber() = default;
 
@@ -62,20 +73,20 @@ public:
 
 #if __cplusplus >= 201103L
   // Move constructors are useful when all your data is on the heap
-  DualNumber(DualNumber<T, D> && /*src*/);
+  DualNumber(DualNumber<T, D, asd> && /*src*/);
 
   // Move assignment avoids heap operations too
-  DualNumber& operator= (DualNumber<T, D> && /*src*/);
+  DualNumber& operator= (DualNumber<T, D, asd> && /*src*/);
 
   // Standard copy operations get implicitly deleted upon move
   // constructor definition, so we redefine them.
-  DualNumber(const DualNumber<T, D> & /*src*/);
+  DualNumber(const DualNumber<T, D, asd> & /*src*/);
 
-  DualNumber& operator= (const DualNumber<T, D> & /*src*/);
+  DualNumber& operator= (const DualNumber<T, D, asd> & /*src*/);
 #endif
 
   template <typename T2, typename D2>
-  DualNumber & operator=(const DualNumber<T2,D2> & dn);
+  DualNumber & operator=(const DualNumber<T2,D2,asd> & dn);
 
   template <typename T2, typename D2>
   DualNumber & operator=(const NotADuckDualNumber<T2,D2> & nd_dn);
@@ -99,45 +110,45 @@ public:
 
   bool boolean_test() const;
 
-  DualNumber<T,D> operator- () const;
+  DualNumber<T,D,asd> operator- () const;
 
-  DualNumber<T,D> operator! () const;
-
-  template <typename T2, typename D2>
-  DualNumber<T, D> & operator+= (const DualNumber<T2,D2>& a);
+  DualNumber<T,D,asd> operator! () const;
 
   template <typename T2, typename D2>
-  DualNumber<T, D> & operator+= (const NotADuckDualNumber<T2,D2>& a);
+  DualNumber<T, D, asd> & operator+= (const DualNumber<T2,D2,asd>& a);
+
+  template <typename T2, typename D2>
+  DualNumber<T, D, asd> & operator+= (const NotADuckDualNumber<T2,D2>& a);
 
   template <typename T2>
-  DualNumber<T, D> & operator+= (const T2& a);
+  DualNumber<T, D, asd> & operator+= (const T2& a);
 
   template <typename T2, typename D2>
-  DualNumber<T, D> & operator-= (const DualNumber<T2,D2>& a);
+  DualNumber<T, D, asd> & operator-= (const DualNumber<T2,D2,asd>& a);
 
   template <typename T2, typename D2>
-  DualNumber<T, D> & operator-= (const NotADuckDualNumber<T2,D2>& a);
+  DualNumber<T, D, asd> & operator-= (const NotADuckDualNumber<T2,D2>& a);
 
   template <typename T2>
-  DualNumber<T, D> & operator-= (const T2& a);
+  DualNumber<T, D, asd> & operator-= (const T2& a);
 
   template <typename T2, typename D2>
-  DualNumber<T, D> & operator*= (const DualNumber<T2,D2>& a);
+  DualNumber<T, D, asd> & operator*= (const DualNumber<T2,D2,asd>& a);
 
   template <typename T2, typename D2>
-  DualNumber<T, D> & operator*= (const NotADuckDualNumber<T2,D2>& a);
+  DualNumber<T, D, asd> & operator*= (const NotADuckDualNumber<T2,D2>& a);
 
   template <typename T2>
-  DualNumber<T, D> & operator*= (const T2& a);
+  DualNumber<T, D, asd> & operator*= (const T2& a);
 
   template <typename T2, typename D2>
-  DualNumber<T, D> & operator/= (const DualNumber<T2,D2>& a);
+  DualNumber<T, D, asd> & operator/= (const DualNumber<T2,D2,asd>& a);
 
   template <typename T2, typename D2>
-  DualNumber<T, D> & operator/= (const NotADuckDualNumber<T2,D2>& a);
+  DualNumber<T, D, asd> & operator/= (const NotADuckDualNumber<T2,D2>& a);
 
   template <typename T2>
-  DualNumber<T, D> & operator/= (const T2& a);
+  DualNumber<T, D, asd> & operator/= (const T2& a);
 
 
   static bool do_derivatives;
@@ -150,10 +161,10 @@ private:
 // Helper class to handle partial specialization for DualNumber
 // constructors
 
-template <typename T, typename D>
+template <typename T, typename D, bool asd = false>
 struct DualNumberConstructor
 {
-  static T value(const DualNumber<T,D>& v) { return v.value(); }
+  static T value(const DualNumber<T,D,asd>& v) { return v.value(); }
 
   template <typename T2>
   static T value(const T2& v) { return v; }
@@ -162,40 +173,40 @@ struct DualNumberConstructor
   static T value(const T2& v, const D2&) { return v; }
 
   template <typename T2, typename D2>
-  static T value(const DualNumber<T2,D2>& v) {
-    return DualNumberConstructor<T,D>::value(v.value());
+  static T value(const DualNumber<T2,D2,asd>& v) {
+    return DualNumberConstructor<T,D,asd>::value(v.value());
   }
 
   template <typename T2>
   static D deriv(const T2&) { return 0.; }
 
   template <typename T2, typename D2>
-  static D deriv(const DualNumber<T2,D2>& v) { return v.derivatives(); }
+  static D deriv(const DualNumber<T2,D2,asd>& v) { return v.derivatives(); }
 
   template <typename T2, typename D2>
   static D deriv(const T2&, const D2& d) { return d; }
 };
 
-template <typename T, typename D, typename DD>
-struct DualNumberConstructor<DualNumber<T,D>, DD>
+template <typename T, typename D, bool asd, typename DD>
+struct DualNumberConstructor<DualNumber<T,D,asd>, DD, asd>
 {
   template <typename T2, typename D2, typename D3>
-  static DualNumber<T,D> value(const DualNumber<DualNumber<T2,D2>, D3>& v) { return v.value(); }
+  static DualNumber<T,D,asd> value(const DualNumber<DualNumber<T2,D2,asd>, D3,asd>& v) { return v.value(); }
 
   template <typename T2>
-  static DualNumber<T,D> value(const T2& v) { return v; }
+  static DualNumber<T,D,asd> value(const T2& v) { return v; }
 
   template <typename T2, typename D2>
-  static DualNumber<T,D> value(const T2& v, const D2& d) { return DualNumber<T,D>(v,d); }
+  static DualNumber<T,D,asd> value(const T2& v, const D2& d) { return DualNumber<T,D,asd>(v,d); }
 
   template <typename D2>
-  static DualNumber<T,D> value(const DualNumber<T,D>& v, const D2&) { return v; }
+  static DualNumber<T,D,asd> value(const DualNumber<T,D,asd>& v, const D2&) { return v; }
 
   template <typename T2>
   static DD deriv(const T2&) { return 0; }
 
   template <typename T2, typename D2>
-  static DD deriv(const DualNumber<T2,D2>& v) { return v.derivatives(); }
+  static DD deriv(const DualNumber<T2,D2,asd>& v) { return v.derivatives(); }
 
   template <typename T2, typename D2>
   static DD deriv(const T2&, const D2& d) { return d; }
@@ -210,22 +221,22 @@ struct DualNumberConstructor<DualNumber<T,D>, DD>
 // errors.
 
 #define DualNumber_decl_preop(opname, functorname) \
-template <typename T, typename D, typename T2, typename D2> \
+template <typename T, typename D, typename T2, typename D2, bool asd>  \
 inline \
-typename functorname##Type<DualNumber<T,D>,DualNumber<T2,D2> >::supertype \
-operator opname (const DualNumber<T,D>& a, const DualNumber<T2,D2>& b); \
+typename functorname##Type<DualNumber<T,D,asd>,DualNumber<T2,D2,asd> >::supertype \
+operator opname (const DualNumber<T,D,asd>& a, const DualNumber<T2,D2,asd>& b); \
  \
  \
-template <typename T, typename T2, typename D> \
+template <typename T, typename T2, typename D, bool asd> \
 inline \
-typename functorname##Type<DualNumber<T2,D>,T,true>::supertype \
-operator opname (const T& a, const DualNumber<T2,D>& b); \
+typename functorname##Type<DualNumber<T2,D,asd>,T,true>::supertype \
+operator opname (const T& a, const DualNumber<T2,D,asd>& b); \
  \
  \
-template <typename T, typename D, typename T2> \
+template <typename T, typename D, typename T2, bool asd> \
 inline \
-typename functorname##Type<DualNumber<T,D>,T2,false>::supertype \
-operator opname (const DualNumber<T,D>& a, const T2& b);
+typename functorname##Type<DualNumber<T,D,asd>,T2,false>::supertype \
+operator opname (const DualNumber<T,D,asd>& a, const T2& b);
 
 
 
@@ -237,16 +248,16 @@ operator opname (const DualNumber<T,D>& a, const T2& b);
 #define DualNumber_decl_op(opname, functorname) \
         DualNumber_decl_preop(opname, functorname) \
  \
-template <typename T, typename D, typename T2, typename D2> \
+template <typename T, typename D, typename T2, typename D2, bool asd> \
 inline \
-typename functorname##Type<DualNumber<T,D>,DualNumber<T2,D2> >::supertype \
-operator opname (DualNumber<T,D>&& a, const DualNumber<T2,D2>& b); \
+typename functorname##Type<DualNumber<T,D,asd>,DualNumber<T2,D2,asd> >::supertype \
+operator opname (DualNumber<T,D,asd>&& a, const DualNumber<T2,D2,asd>& b); \
  \
  \
-template <typename T, typename D, typename T2> \
+template <typename T, typename D, typename T2, bool asd> \
 inline \
-typename functorname##Type<DualNumber<T,D>,T2,false>::supertype \
-operator opname (DualNumber<T,D>&& a, const T2& b); \
+typename functorname##Type<DualNumber<T,D,asd>,T2,false>::supertype \
+operator opname (DualNumber<T,D,asd>&& a, const T2& b); \
 
 #else
 #define DualNumber_decl_op(opname, functorname) \
@@ -259,28 +270,28 @@ DualNumber_decl_op(*, Multiplies)
 DualNumber_decl_op(/, Divides)
 
 #define DualNumber_decl_compare(opname)                     \
-template <typename T, typename D, typename T2, typename D2> \
+template <typename T, typename D, typename T2, typename D2, bool asd> \
 inline \
 bool \
-operator opname  (const DualNumber<T,D>& a, const DualNumber<T2,D2>& b); \
+operator opname  (const DualNumber<T,D,asd>& a, const DualNumber<T2,D2,asd>& b); \
  \
  \
-template <typename T, typename T2, typename D2> \
+template <typename T, typename T2, typename D2, bool asd> \
 inline \
 typename boostcopy::enable_if_class< \
-  typename CompareTypes<DualNumber<T2,D2>,T>::supertype, \
+  typename CompareTypes<DualNumber<T2,D2,asd>,T>::supertype, \
   bool \
 >::type \
-operator opname  (const T& a, const DualNumber<T2,D2>& b); \
+operator opname  (const T& a, const DualNumber<T2,D2,asd>& b); \
  \
  \
-template <typename T, typename T2, typename D> \
+template <typename T, typename T2, typename D, bool asd> \
 inline \
 typename boostcopy::enable_if_class< \
-  typename CompareTypes<DualNumber<T,D>,T2>::supertype, \
+  typename CompareTypes<DualNumber<T,D,asd>,T2>::supertype, \
   bool \
 >::type \
-operator opname  (const DualNumber<T,D>& a, const T2& b);
+operator opname  (const DualNumber<T,D,asd>& a, const T2& b);
 
 DualNumber_decl_compare(>)
 DualNumber_decl_compare(>=)
@@ -291,111 +302,117 @@ DualNumber_decl_compare(!=)
 DualNumber_decl_compare(&&)
 DualNumber_decl_compare(||)
 
-template <typename T, typename D>
+template <typename T, typename D, bool asd>
 inline
 std::ostream&
-operator<< (std::ostream& output, const DualNumber<T,D>& a);
+operator<< (std::ostream& output, const DualNumber<T,D,asd>& a);
 
 
 // ScalarTraits, RawType, CompareTypes specializations
 
-template <typename T, typename D>
-struct ScalarTraits<DualNumber<T, D> >
+template <typename T, typename D, bool asd>
+struct ScalarTraits<DualNumber<T, D, asd> >
 {
   static const bool value = ScalarTraits<T>::value;
 };
 
-template <typename T, typename D>
-struct RawType<DualNumber<T, D> >
+template <typename T, typename D, bool asd>
+struct RawType<DualNumber<T, D, asd> >
 {
   typedef typename RawType<T>::value_type value_type;
 
-  static value_type value(const DualNumber<T, D>& a) { return raw_value(a.value()); }
+  static value_type value(const DualNumber<T, D, asd>& a) { return raw_value(a.value()); }
 };
 
-template<typename T, typename T2, typename D, bool reverseorder>
-struct PlusType<DualNumber<T, D>, T2, reverseorder,
+template<typename T, typename T2, typename D, bool asd, bool reverseorder>
+struct PlusType<DualNumber<T, D, asd>, T2, reverseorder,
                     typename boostcopy::enable_if<BuiltinTraits<T2> >::type> {
-  typedef DualNumber<typename SymmetricPlusType<T, T2, reverseorder>::supertype, D> supertype;
+  typedef DualNumber<typename SymmetricPlusType<T, T2, reverseorder>::supertype, D, asd> supertype;
 };
 
-template<typename T, typename D, typename T2, typename D2, bool reverseorder>
-struct PlusType<DualNumber<T, D>, DualNumber<T2, D2>, reverseorder> {
+template<typename T, typename D, typename T2, typename D2, bool asd, bool reverseorder>
+struct PlusType<DualNumber<T, D, asd>, DualNumber<T2, D2, asd>, reverseorder> {
   typedef DualNumber<typename SymmetricPlusType<T, T2, reverseorder>::supertype,
-                     typename SymmetricPlusType<D, D2, reverseorder>::supertype> supertype;
+                     typename SymmetricPlusType<D, D2, reverseorder>::supertype,
+                     asd> supertype;
 };
 
-template<typename T, typename D>
-struct PlusType<DualNumber<T, D>, DualNumber<T, D> > {
+template<typename T, typename D, bool asd>
+struct PlusType<DualNumber<T, D, asd>, DualNumber<T, D, asd> > {
   typedef DualNumber<typename SymmetricPlusType<T,T>::supertype,
-                     typename SymmetricPlusType<D,D>::supertype> supertype;
+                     typename SymmetricPlusType<D,D>::supertype,
+                     asd> supertype;
 };
 
 
-template<typename T, typename T2, typename D, bool reverseorder>
-struct MinusType<DualNumber<T, D>, T2, reverseorder,
+template<typename T, typename T2, typename D, bool asd, bool reverseorder>
+struct MinusType<DualNumber<T, D, asd>, T2, reverseorder,
                     typename boostcopy::enable_if<BuiltinTraits<T2> >::type> {
-  typedef DualNumber<typename SymmetricMinusType<T, T2, reverseorder>::supertype, D> supertype;
+  typedef DualNumber<typename SymmetricMinusType<T, T2, reverseorder>::supertype, D, asd> supertype;
 };
 
-template<typename T, typename D, typename T2, typename D2, bool reverseorder>
-struct MinusType<DualNumber<T, D>, DualNumber<T2, D2>, reverseorder> {
+template<typename T, typename D, typename T2, typename D2, bool asd, bool reverseorder>
+struct MinusType<DualNumber<T, D, asd>, DualNumber<T2, D2, asd>, reverseorder> {
   typedef DualNumber<typename SymmetricMinusType<T, T2, reverseorder>::supertype,
-                     typename SymmetricMinusType<D, D2, reverseorder>::supertype> supertype;
+                     typename SymmetricMinusType<D, D2, reverseorder>::supertype,
+                     asd> supertype;
 };
 
-template<typename T, typename D, bool reverseorder>
-struct MinusType<DualNumber<T, D>, DualNumber<T, D>, reverseorder> {
+template<typename T, typename D, bool asd, bool reverseorder>
+struct MinusType<DualNumber<T, D, asd>, DualNumber<T, D, asd>, reverseorder> {
   typedef DualNumber<typename SymmetricMinusType<T,T>::supertype,
-                     typename SymmetricMinusType<D,D>::supertype> supertype;
+                     typename SymmetricMinusType<D,D>::supertype,
+                     asd> supertype;
 };
 
 
-template<typename T, typename T2, typename D, bool reverseorder>
-struct MultipliesType<DualNumber<T, D>, T2, reverseorder,
+template<typename T, typename T2, typename D, bool asd, bool reverseorder>
+struct MultipliesType<DualNumber<T, D, asd>, T2, reverseorder,
                       typename boostcopy::enable_if<BuiltinTraits<T2> >::type> {
   typedef DualNumber<typename SymmetricMultipliesType<T, T2, reverseorder>::supertype,
-                     typename SymmetricMultipliesType<D, T2, reverseorder>::supertype> supertype;
+                     typename SymmetricMultipliesType<D, T2, reverseorder>::supertype,
+                     asd> supertype;
 };
 
-template<typename T, typename D, typename T2, typename D2, bool reverseorder>
-struct MultipliesType<DualNumber<T, D>, DualNumber<T2, D2>, reverseorder> {
+template<typename T, typename D, typename T2, typename D2, bool asd, bool reverseorder>
+struct MultipliesType<DualNumber<T, D, asd>, DualNumber<T2, D2, asd>, reverseorder> {
   typedef DualNumber<typename SymmetricMultipliesType<T, T2, reverseorder>::supertype,
                      typename SymmetricPlusType<
                        typename SymmetricMultipliesType<T, D2, reverseorder>::supertype,
-                       typename SymmetricMultipliesType<D, T2, reverseorder>::supertype>::supertype
-                     > supertype;
+                       typename SymmetricMultipliesType<D, T2, reverseorder>::supertype>::supertype,
+                     asd> supertype;
 };
 
-template<typename T, typename D, bool reverseorder>
-struct MultipliesType<DualNumber<T, D>, DualNumber<T, D>, reverseorder> {
+template<typename T, typename D, bool asd, bool reverseorder>
+struct MultipliesType<DualNumber<T, D, asd>, DualNumber<T, D, asd>, reverseorder> {
   typedef DualNumber<typename SymmetricMultipliesType<T, T, reverseorder>::supertype,
-                     typename SymmetricMultipliesType<T, D, reverseorder>::supertype
-                     > supertype;
+                     typename SymmetricMultipliesType<T, D, reverseorder>::supertype,
+                     asd> supertype;
 };
 
 
-template<typename T, typename T2, typename D>
-struct DividesType<DualNumber<T, D>, T2, false,
+template<typename T, typename T2, typename D, bool asd>
+struct DividesType<DualNumber<T, D, asd>, T2, false,
                       typename boostcopy::enable_if<BuiltinTraits<T2> >::type> {
   typedef DualNumber<typename SymmetricDividesType<T, T2>::supertype,
-                     typename SymmetricDividesType<D, T2>::supertype> supertype;
+                     typename SymmetricDividesType<D, T2>::supertype,
+                     asd> supertype;
 };
 
-template<typename T, typename D, typename T2>
-struct DividesType<DualNumber<T, D>, T2, true,
+template<typename T, typename D, typename T2, bool asd>
+struct DividesType<DualNumber<T, D, asd>, T2, true,
                    typename boostcopy::enable_if<BuiltinTraits<T2> >::type> {
   typedef DualNumber<typename SymmetricDividesType<T2, T>::supertype,
                      typename SymmetricDividesType<
                        typename SymmetricMultipliesType<T2, D>::supertype,
                        T
-                     >::supertype
-                    > supertype;
+                     >::supertype,
+                    asd> supertype;
 };
 
 
-template<typename T, typename D, typename T2, typename D2>
-struct DividesType<DualNumber<T, D>, DualNumber<T2, D2>, false> {
+template<typename T, typename D, typename T2, typename D2, bool asd>
+struct DividesType<DualNumber<T, D, asd>, DualNumber<T2, D2, asd>, false> {
   typedef DualNumber<typename SymmetricDividesType<T, T2>::supertype,
                      typename SymmetricMinusType<
                        typename SymmetricDividesType<T2, D>::supertype,
@@ -403,17 +420,17 @@ struct DividesType<DualNumber<T, D>, DualNumber<T2, D2>, false> {
                          typename SymmetricMultipliesType<T, D2>::supertype,
                          T2
                        >::supertype
-                     >::supertype
-                    > supertype;
+                     >::supertype,
+                    asd> supertype;
 };
 
-template<typename T, typename D, typename T2, typename D2>
-struct DividesType<DualNumber<T, D>, DualNumber<T2, D2>, true> {
-  typedef typename DividesType<DualNumber<T2, D2>, DualNumber<T, D>, false>::supertype supertype;
+template<typename T, typename D, typename T2, typename D2, bool asd>
+struct DividesType<DualNumber<T, D, asd>, DualNumber<T2, D2, asd>, true> {
+  typedef typename DividesType<DualNumber<T2, D2, asd>, DualNumber<T, D, asd>, false>::supertype supertype;
 };
 
-template<typename T, typename D>
-struct DividesType<DualNumber<T, D>, DualNumber<T, D>, false> {
+template<typename T, typename D, bool asd>
+struct DividesType<DualNumber<T, D, asd>, DualNumber<T, D, asd>, false> {
   typedef DualNumber<T,
                      typename SymmetricMinusType<
                        typename SymmetricDividesType<T, D>::supertype,
@@ -421,47 +438,47 @@ struct DividesType<DualNumber<T, D>, DualNumber<T, D>, false> {
                          typename SymmetricMultipliesType<T, D>::supertype,
                          T
                        >::supertype
-                     >::supertype
-                    > supertype;
+                     >::supertype,
+                    asd> supertype;
 };
 
-template<typename T, typename D>
-struct DividesType<DualNumber<T, D>, DualNumber<T, D>, true> {
-  typedef typename DividesType<DualNumber<T, D>, DualNumber<T, D>, false>::supertype supertype;
+template<typename T, typename D, bool asd>
+struct DividesType<DualNumber<T, D, asd>, DualNumber<T, D, asd>, true> {
+  typedef typename DividesType<DualNumber<T, D, asd>, DualNumber<T, D, asd>, false>::supertype supertype;
 };
 
-template<typename T, typename T2, typename D, bool reverseorder>
-struct AndType<DualNumber<T, D>, T2, reverseorder,
+template<typename T, typename T2, typename D, bool asd, bool reverseorder>
+struct AndType<DualNumber<T, D, asd>, T2, reverseorder,
                typename boostcopy::enable_if<BuiltinTraits<T2> >::type> {
   typedef DualNumber<typename SymmetricAndType<T, T2, reverseorder>::supertype, bool> supertype;
 };
 
-template<typename T, typename D, typename T2, typename D2, bool reverseorder>
-struct AndType<DualNumber<T, D>, DualNumber<T2, D2>, reverseorder> {
+template<typename T, typename D, typename T2, typename D2, bool asd, bool reverseorder>
+struct AndType<DualNumber<T, D, asd>, DualNumber<T2, D2, asd>, reverseorder> {
   typedef DualNumber<typename SymmetricAndType<T, T2, reverseorder>::supertype,
                      bool> supertype;
 };
 
-template<typename T, typename D>
-struct AndType<DualNumber<T, D>, DualNumber<T, D> > {
+template<typename T, typename D, bool asd>
+struct AndType<DualNumber<T, D, asd>, DualNumber<T, D, asd> > {
   typedef DualNumber<typename SymmetricAndType<T,T>::supertype,
                      bool> supertype;
 };
 
-template<typename T, typename T2, typename D, bool reverseorder>
-struct OrType<DualNumber<T, D>, T2, reverseorder,
+template<typename T, typename T2, typename D, bool asd, bool reverseorder>
+struct OrType<DualNumber<T, D, asd>, T2, reverseorder,
               typename boostcopy::enable_if<BuiltinTraits<T2> >::type> {
   typedef DualNumber<typename SymmetricOrType<T, T2, reverseorder>::supertype, bool> supertype;
 };
 
-template<typename T, typename D, typename T2, typename D2, bool reverseorder>
-struct OrType<DualNumber<T, D>, DualNumber<T2, D2>, reverseorder> {
+template<typename T, typename D, typename T2, typename D2, bool asd, bool reverseorder>
+struct OrType<DualNumber<T, D, asd>, DualNumber<T2, D2, asd>, reverseorder> {
   typedef DualNumber<typename SymmetricOrType<T, T2, reverseorder>::supertype,
                      bool> supertype;
 };
 
-template<typename T, typename D>
-struct OrType<DualNumber<T, D>, DualNumber<T, D> > {
+template<typename T, typename D, bool asd>
+struct OrType<DualNumber<T, D, asd>, DualNumber<T, D, asd> > {
   typedef DualNumber<typename SymmetricOrType<T,T>::supertype,
                      bool> supertype;
 };
@@ -469,35 +486,35 @@ struct OrType<DualNumber<T, D>, DualNumber<T, D> > {
 
 
 
-template<typename T, typename T2, typename D, bool reverseorder>
-struct CompareTypes<DualNumber<T, D>, T2, reverseorder,
+template<typename T, typename T2, typename D, bool asd, bool reverseorder>
+struct CompareTypes<DualNumber<T, D, asd>, T2, reverseorder,
                     typename boostcopy::enable_if<BuiltinTraits<T2> >::type> {
   typedef DualNumber<typename SymmetricCompareTypes<T, T2>::supertype,
                      typename SymmetricCompareTypes<
                        typename SymmetricCompareTypes<D, T2>::supertype,
                        T
-                     >::supertype> supertype;
+                     >::supertype, asd> supertype;
 };
 
-template<typename T, typename D, typename T2, typename D2>
-struct CompareTypes<DualNumber<T, D>, DualNumber<T2, D2> > {
+template<typename T, typename D, typename T2, typename D2, bool asd>
+struct CompareTypes<DualNumber<T, D, asd>, DualNumber<T2, D2, asd> > {
   typedef DualNumber<typename SymmetricCompareTypes<T, T2>::supertype,
                      typename SymmetricCompareTypes<
                        typename SymmetricCompareTypes<T, T2>::supertype,
                        typename SymmetricCompareTypes<D, D2>::supertype
-                     >::supertype
-                    > supertype;
+                     >::supertype,
+                    asd> supertype;
 };
 
-template<typename T, typename D>
-struct CompareTypes<DualNumber<T, D>, DualNumber<T, D> > {
-  typedef DualNumber<T, typename SymmetricCompareTypes<T, D>::supertype> supertype;
+template<typename T, typename D, bool asd>
+struct CompareTypes<DualNumber<T, D, asd>, DualNumber<T, D, asd> > {
+  typedef DualNumber<T, typename SymmetricCompareTypes<T, D>::supertype, asd> supertype;
 };
 
 
-template <typename T, typename D>
+template <typename T, typename D, bool asd>
 inline
-D gradient(const DualNumber<T, D>& a);
+D gradient(const DualNumber<T, D, asd>& a);
 
 } // namespace MetaPhysicL
 
@@ -507,32 +524,32 @@ namespace std {
 using MetaPhysicL::DualNumber;
 using MetaPhysicL::CompareTypes;
 
-template <typename T, typename D>
-inline bool isnan (const DualNumber<T,D> & a);
+template <typename T, typename D, bool asd>
+inline bool isnan (const DualNumber<T,D,asd> & a);
 
 // Some forward declarations necessary for recursive DualNumbers
 
 #if __cplusplus >= 201103L
 
-template <typename T, typename D>
-inline DualNumber<T,D> cos  (const DualNumber<T,D> & a);
+template <typename T, typename D, bool asd>
+inline DualNumber<T,D,asd> cos  (const DualNumber<T,D,asd> & a);
 
-template <typename T, typename D>
-inline DualNumber<T,D> cos  (DualNumber<T,D> && a);
+template <typename T, typename D, bool asd>
+inline DualNumber<T,D,asd> cos  (DualNumber<T,D,asd> && a);
 
-template <typename T, typename D>
-inline DualNumber<T,D> cosh (const DualNumber<T,D> & a);
+template <typename T, typename D, bool asd>
+inline DualNumber<T,D,asd> cosh (const DualNumber<T,D,asd> & a);
 
-template <typename T, typename D>
-inline DualNumber<T,D> cosh (DualNumber<T,D> && a);
+template <typename T, typename D, bool asd>
+inline DualNumber<T,D,asd> cosh (DualNumber<T,D,asd> && a);
 
 #else
 
-template <typename T, typename D>
-inline DualNumber<T,D> cos  (DualNumber<T,D> a);
+template <typename T, typename D, bool asd>
+inline DualNumber<T,D,asd> cos  (DualNumber<T,D,asd> a);
 
-template <typename T, typename D>
-inline DualNumber<T,D> cosh (DualNumber<T,D> a);
+template <typename T, typename D, bool asd>
+inline DualNumber<T,D,asd> cosh (DualNumber<T,D,asd> a);
 
 #endif
 
@@ -540,22 +557,22 @@ inline DualNumber<T,D> cosh (DualNumber<T,D> a);
 
 #if __cplusplus >= 201103L
 #define DualNumber_decl_std_unary(funcname) \
-template <typename T, typename D> \
+template <typename T, typename D, bool asd> \
 inline \
-DualNumber<T,D> funcname (const DualNumber<T,D> & in); \
+DualNumber<T,D,asd> funcname (const DualNumber<T,D,asd> & in); \
  \
  \
-template <typename T, typename D> \
+template <typename T, typename D, bool asd> \
 inline \
-DualNumber<T,D> funcname (DualNumber<T,D> && in);
+DualNumber<T,D,asd> funcname (DualNumber<T,D,asd> && in);
 
 
 #else
 
 #define DualNumber_decl_std_unary(funcname) \
-template <typename T, typename D> \
+template <typename T, typename D, bool asd> \
 inline \
-DualNumber<T,D> funcname (DualNumber<T,D> in);
+DualNumber<T,D,asd> funcname (DualNumber<T,D,asd> in);
 
 #endif
 
@@ -622,12 +639,12 @@ DualNumber_decl_stdfl_unary(rint)
 #endif // __cplusplus >= 201103L
 
 #define DualNumber_decl_complex_std_unary_real(funcname) \
-template <typename T, typename D> \
-inline DualNumber<T, typename D::template rebind<T>::other> \
-funcname(const DualNumber<std::complex<T>, D> & in); \
-template <typename T> \
-inline DualNumber<T> \
-funcname(const DualNumber<std::complex<T>> & in)
+template <typename T, typename D, bool asd> \
+inline DualNumber<T, typename D::template rebind<T>::other, asd> \
+funcname(const DualNumber<std::complex<T>, D, asd> & in); \
+template <typename T, bool asd> \
+inline DualNumber<T,T,asd> \
+funcname(const DualNumber<std::complex<T>,std::complex<T>,asd> & in)
 
 DualNumber_decl_complex_std_unary_real(real);
 DualNumber_decl_complex_std_unary_real(imag);
@@ -635,23 +652,23 @@ DualNumber_decl_complex_std_unary_real(norm);
 DualNumber_decl_complex_std_unary_real(abs);
 
 #define DualNumber_decl_complex_std_unary_complex_pre(funcname) \
-template <typename T, typename D> \
-inline DualNumber<std::complex<T>, D> \
-funcname(const DualNumber<std::complex<T>, D> & in); \
-template <typename T> \
-inline DualNumber<std::complex<T>> \
-funcname(const DualNumber<std::complex<T>> & in)
+template <typename T, typename D, bool asd> \
+inline DualNumber<std::complex<T>, D, asd> \
+funcname(const DualNumber<std::complex<T>, D, asd> & in); \
+template <typename T, bool asd> \
+inline DualNumber<std::complex<T>,std::complex<T>,asd> \
+funcname(const DualNumber<std::complex<T>,std::complex<T>,asd> & in)
 
 #if __cplusplus >= 201103L
 #define DualNumber_decl_complex_std_unary_complex(funcname) \
 DualNumber_decl_complex_std_unary_complex_pre(funcname);  \
-template <typename T, typename D> \
-inline DualNumber<std::complex<T>, D> \
-funcname(DualNumber<std::complex<T>, D> && in); \
+template <typename T, typename D, bool asd> \
+inline DualNumber<std::complex<T>, D, asd> \
+funcname(DualNumber<std::complex<T>, D, asd> && in); \
  \
-template <typename T> \
-inline DualNumber<std::complex<T>> \
-funcname(DualNumber<std::complex<T>> && in)
+template <typename T, bool asd> \
+inline DualNumber<std::complex<T>,std::complex<T>,asd> \
+funcname(DualNumber<std::complex<T>,std::complex<T>,asd> && in)
 
 #else
 #define DualNumber_decl_complex_std_unary_complex(funcname) \
@@ -661,28 +678,28 @@ DualNumber_complex_std_unary_complex_pre(funcname);
 DualNumber_decl_complex_std_unary_complex(conj);
 
 #define DualNumber_decl_std_binary(funcname)                \
-template <typename T, typename D, typename T2, typename D2> \
+template <typename T, typename D, typename T2, typename D2, bool asd> \
 inline \
-typename CompareTypes<DualNumber<T,D>,DualNumber<T2,D2> >::supertype \
-funcname (const DualNumber<T,D>& a, const DualNumber<T2,D2>& b); \
+typename CompareTypes<DualNumber<T,D,asd>,DualNumber<T2,D2,asd> >::supertype \
+funcname (const DualNumber<T,D,asd>& a, const DualNumber<T2,D2,asd>& b); \
  \
  \
-template <typename T, typename D> \
+template <typename T, typename D, bool asd> \
 inline \
-DualNumber<T,D> \
-funcname (const DualNumber<T,D>& a, const DualNumber<T,D>& b); \
+DualNumber<T,D,asd> \
+funcname (const DualNumber<T,D,asd>& a, const DualNumber<T,D,asd>& b); \
  \
  \
-template <typename T, typename T2, typename D> \
+template <typename T, typename T2, typename D, bool asd> \
 inline \
-typename CompareTypes<DualNumber<T2,D>,T,true>::supertype \
-funcname (const T& a, const DualNumber<T2,D>& b); \
+typename CompareTypes<DualNumber<T2,D,asd>,T,true>::supertype \
+funcname (const T& a, const DualNumber<T2,D,asd>& b); \
  \
  \
-template <typename T, typename T2, typename D> \
+template <typename T, typename T2, typename D, bool asd> \
 inline \
-typename CompareTypes<DualNumber<T,D>,T2>::supertype \
-funcname (const DualNumber<T,D>& a, const T2& b);
+typename CompareTypes<DualNumber<T,D,asd>,T2>::supertype \
+funcname (const DualNumber<T,D,asd>& a, const T2& b);
 
 #define DualNumber_decl_fl_binary(funcname) \
 DualNumber_decl_std_binary(funcname##f) \
@@ -709,9 +726,9 @@ DualNumber_decl_stdfl_binary(hypot)
 DualNumber_decl_fl_binary(atan2)
 #endif // __cplusplus >= 201103L
 
-template <typename T, typename D>
-class numeric_limits<DualNumber<T, D> > :
-  public MetaPhysicL::raw_numeric_limits<DualNumber<T, D>, T> {};
+template <typename T, typename D, bool asd>
+class numeric_limits<DualNumber<T, D, asd> > :
+  public MetaPhysicL::raw_numeric_limits<DualNumber<T, D, asd>, T> {};
 
 } // namespace std
 

--- a/src/numerics/include/metaphysicl/dualnumber_decl.h
+++ b/src/numerics/include/metaphysicl/dualnumber_decl.h
@@ -62,16 +62,16 @@ public:
 
 #if __cplusplus >= 201103L
   // Move constructors are useful when all your data is on the heap
-  DualNumber(DualNumber<T, D> && /*src*/) = default;
+  DualNumber(DualNumber<T, D> && /*src*/);
 
   // Move assignment avoids heap operations too
-  DualNumber& operator= (DualNumber<T, D> && /*src*/) = default;
+  DualNumber& operator= (DualNumber<T, D> && /*src*/);
 
   // Standard copy operations get implicitly deleted upon move
   // constructor definition, so we redefine them.
-  DualNumber(const DualNumber<T, D> & /*src*/) = default;
+  DualNumber(const DualNumber<T, D> & /*src*/);
 
-  DualNumber& operator= (const DualNumber<T, D> & /*src*/) = default;
+  DualNumber& operator= (const DualNumber<T, D> & /*src*/);
 #endif
 
   template <typename T2, typename D2>
@@ -139,6 +139,8 @@ public:
   template <typename T2>
   DualNumber<T, D> & operator/= (const T2& a);
 
+
+  static bool do_derivatives;
 
 private:
   T _val;

--- a/src/numerics/include/metaphysicl/dualnumber_forward.h
+++ b/src/numerics/include/metaphysicl/dualnumber_forward.h
@@ -21,37 +21,17 @@
 //
 //-----------------------------------------------------------------------el-
 //
-// $Id: core.h 37197 2013-02-21 05:49:09Z roystgnr $
+// $Id$
 //
 //--------------------------------------------------------------------------
 
-#ifndef METAPHYSICL_DUALSHADOW_H
-#define METAPHYSICL_DUALSHADOW_H
+#ifndef METAPHYSICL_DUALNUMBER_FORWARD_H
+#define METAPHYSICL_DUALNUMBER_FORWARD_H
 
-// Order of declarations is important here?
-#include "metaphysicl/shadownumber.h"
-#include "metaphysicl/dualnumber.h"
-
-// ShadowNumber is subordinate to DualNumber:
-
-#define DualShadow_comparisons(templatename) \
-template<typename T, typename D, typename T2, typename S, bool asd, bool reverseorder> \
-struct templatename<DualNumber<T, D, asd>, ShadowNumber<T2, S>, reverseorder> { \
-  typedef DualNumber<typename Symmetric##templatename<T, ShadowNumber<T2, S>, reverseorder>::supertype, \
-                     typename Symmetric##templatename<D, ShadowNumber<T2, S>, reverseorder>::supertype, \
-                     asd> supertype; \
+namespace MetaPhysicL
+{
+template <typename T, typename D = T, bool asd = false>
+class DualNumber;
 }
 
-namespace MetaPhysicL {
-
-DualShadow_comparisons(CompareTypes);
-DualShadow_comparisons(PlusType);
-DualShadow_comparisons(MinusType);
-DualShadow_comparisons(MultipliesType);
-DualShadow_comparisons(DividesType);
-DualShadow_comparisons(AndType);
-DualShadow_comparisons(OrType);
-
-} // namespace MetaPhysicL
-
-#endif // METAPHYSICL_DUALSHADOW_H
+#endif

--- a/src/numerics/include/metaphysicl/dualnumber_surrogate_decl.h
+++ b/src/numerics/include/metaphysicl/dualnumber_surrogate_decl.h
@@ -1,11 +1,10 @@
 #ifndef METAPHYSICL_DUALNUMBER_SURROGATE_DECL_H
 #define METAPHYSICL_DUALNUMBER_SURROGATE_DECL_H
 
+#include "metaphysicl/dualnumber_forward.h"
+
 namespace MetaPhysicL
 {
-
-template <typename T, typename D>
-class DualNumber;
 
 // Surrogate structure that refers/points to a component of a DualNumber, e.g. it might correspond
 // to the ij'th component of a DualNumber<TypeTensor<T>, N>

--- a/src/numerics/include/metaphysicl/dualnumberarray.h
+++ b/src/numerics/include/metaphysicl/dualnumberarray.h
@@ -134,9 +134,9 @@ gradient(const NumberArray<size, T>& a)
 // DualNumber is subordinate to NumberArray
 
 #define DualNumberArray_comparisons(templatename) \
-template<typename T, typename D, std::size_t size, typename T2, bool reverseorder> \
-struct templatename<NumberArray<size, T2>, DualNumber<T, D>, reverseorder> { \
-  typedef NumberArray<size, typename Symmetric##templatename<DualNumber<T, D>, T2, reverseorder>::supertype> supertype; \
+template<typename T, typename D, std::size_t size, typename T2, bool asd, bool reverseorder> \
+struct templatename<NumberArray<size, T2>, DualNumber<T, D, asd>, reverseorder> { \
+  typedef NumberArray<size, typename Symmetric##templatename<DualNumber<T, D, asd>, T2, reverseorder>::supertype> supertype; \
 }
 
 DualNumberArray_comparisons(CompareTypes);

--- a/src/numerics/include/metaphysicl/dualnumbervector.h
+++ b/src/numerics/include/metaphysicl/dualnumbervector.h
@@ -105,7 +105,7 @@ struct DerivativeOf<NumberVector<size, T>, derivativeindex>
     typename DerivativeType<NumberVector<size, T> >::type returnval;
     for (unsigned int i=0; i != size; ++i)
       returnval[i] = DerivativeOf<T,derivativeindex>::derivative(a[i]);
-  
+
     return returnval;
   }
 };
@@ -164,9 +164,9 @@ gradient(const NumberVector<size, T>& a)
 // DualNumber is subordinate to NumberVector
 
 #define DualNumberVector_comparisons(templatename) \
-template<typename T, typename D, std::size_t size, typename T2, bool reverseorder> \
-struct templatename<NumberVector<size, T2>, DualNumber<T, D>, reverseorder> { \
-  typedef NumberVector<size, typename Symmetric##templatename<DualNumber<T, D>, T2, reverseorder>::supertype> supertype; \
+template<typename T, typename D, std::size_t size, typename T2, bool asd, bool reverseorder> \
+struct templatename<NumberVector<size, T2>, DualNumber<T, D, asd>, reverseorder> { \
+  typedef NumberVector<size, typename Symmetric##templatename<DualNumber<T, D, asd>, T2, reverseorder>::supertype> supertype; \
 }
 
 DualNumberVector_comparisons(CompareTypes);

--- a/src/numerics/include/metaphysicl/dualsemidynamicsparsenumberarray_decl.h
+++ b/src/numerics/include/metaphysicl/dualsemidynamicsparsenumberarray_decl.h
@@ -73,11 +73,17 @@ gradient(const SemiDynamicSparseNumberArray<T, I, N> & a);
 // DualNumber is subordinate to SemiDynamicSparseNumberArray
 
 #define DualSemiDynamicSparseNumberArray_comparisons(templatename)                                 \
-  template <typename T, typename T2, typename D, typename I, typename N, bool reverseorder>        \
-  struct templatename<SemiDynamicSparseNumberArray<T2, I, N>, DualNumber<T, D>, reverseorder>      \
+  template <typename T,                                                                            \
+            typename T2,                                                                           \
+            typename D,                                                                            \
+            typename I,                                                                            \
+            typename N,                                                                            \
+            bool asd,                                                                              \
+            bool reverseorder>                                                                     \
+  struct templatename<SemiDynamicSparseNumberArray<T2, I, N>, DualNumber<T, D, asd>, reverseorder> \
   {                                                                                                \
     typedef SemiDynamicSparseNumberArray<                                                          \
-        typename Symmetric##templatename<T2, DualNumber<T, D>, reverseorder>::supertype,           \
+        typename Symmetric##templatename<T2, DualNumber<T, D, asd>, reverseorder>::supertype,      \
         I,                                                                                         \
         N>                                                                                         \
         supertype;                                                                                 \

--- a/src/numerics/include/metaphysicl/dualsparsenumberarray.h
+++ b/src/numerics/include/metaphysicl/dualsparsenumberarray.h
@@ -105,7 +105,7 @@ struct DivergenceArrayFunctor {
   DivergenceArrayFunctor
     (const T* in, typename DerivativeType<T>::type& out) :
       _in(in), _out(out) { out = 0; }
-    
+
   template <typename ValueType>
   inline void operator()() const {
     const unsigned int
@@ -171,9 +171,9 @@ gradient(const SparseNumberArray<T, IndexSet>& a)
 // DualNumber is subordinate to SparseNumberArray
 
 #define DualSparseNumberArray_comparisons(templatename) \
-template<typename T, typename T2, typename D, typename IndexSet, bool reverseorder> \
-struct templatename<SparseNumberArray<T2, IndexSet>, DualNumber<T, D>, reverseorder> { \
-  typedef SparseNumberArray<typename Symmetric##templatename<T2,DualNumber<T, D>,reverseorder>::supertype, IndexSet> supertype; \
+template<typename T, typename T2, typename D, typename IndexSet, bool asd, bool reverseorder> \
+struct templatename<SparseNumberArray<T2, IndexSet>, DualNumber<T, D, asd>, reverseorder> { \
+  typedef SparseNumberArray<typename Symmetric##templatename<T2,DualNumber<T, D, asd>,reverseorder>::supertype, IndexSet> supertype; \
 }
 
 DualSparseNumberArray_comparisons(CompareTypes);

--- a/src/numerics/include/metaphysicl/dualsparsenumberstruct.h
+++ b/src/numerics/include/metaphysicl/dualsparsenumberstruct.h
@@ -202,7 +202,7 @@ inline
 typename DerivativeType<typename MetaPhysicL::ContainerSupertype<IndexSet>::type>::type
 divergence(const SparseNumberStruct<IndexSet>& a)
 {
-  typedef typename 
+  typedef typename
     DerivativeType<
       typename MetaPhysicL::ContainerSupertype<IndexSet>::type
     >::type
@@ -268,25 +268,25 @@ gradient(const SparseNumberStruct<IndexSet>& a)
 
 
 #define DualSparseNumberStruct_comparisons(templatename) \
-template<typename T, typename D, typename IndexSet, bool reverseorder> \
-struct templatename<SparseNumberStruct<IndexSet>, DualNumber<T, D>, reverseorder> { \
-  typedef SparseNumberStruct<typename Symmetric##templatename<IndexSet, DualNumber<T, D>, reverseorder>::supertype> supertype; \
+template<typename T, typename D, typename IndexSet, bool asd, bool reverseorder> \
+struct templatename<SparseNumberStruct<IndexSet>, DualNumber<T, D, asd>, reverseorder> { \
+  typedef SparseNumberStruct<typename Symmetric##templatename<IndexSet, DualNumber<T, D, asd>, reverseorder>::supertype> supertype; \
 }; \
  \
-template<typename T, typename D, bool reverseorder> \
-struct templatename<DualNumber<T, D>, MetaPhysicL::NullType, reverseorder> { \
-  typedef DualNumber<T, D> supertype; \
+template<typename T, typename D, bool asd, bool reverseorder> \
+struct templatename<DualNumber<T, D, asd>, MetaPhysicL::NullType, reverseorder> { \
+  typedef DualNumber<T, D, asd> supertype; \
 }; \
  \
-template<typename T, typename D, typename HeadType, typename TailSet, typename Comparison, bool reverseorder> \
-struct templatename<MetaPhysicL::Container<HeadType,TailSet,Comparison>, DualNumber<T,D>, reverseorder> { \
+template<typename T, typename D, typename HeadType, typename TailSet, typename Comparison, bool asd, bool reverseorder> \
+struct templatename<MetaPhysicL::Container<HeadType,TailSet,Comparison>, DualNumber<T,D,asd>, reverseorder> { \
   typedef typename \
-    MetaPhysicL::Container<HeadType,TailSet,Comparison>::template UpgradeType<DualNumber<T, D> >::type \
+    MetaPhysicL::Container<HeadType,TailSet,Comparison>::template UpgradeType<DualNumber<T, D, asd> >::type \
       supertype; \
 }; \
  \
-template<typename NullHeadType, typename T, typename D, bool reverseorder> \
-struct templatename<MetaPhysicL::NullContainer<NullHeadType>, DualNumber<T, D>, reverseorder> { \
+template<typename NullHeadType, typename T, typename D, bool asd, bool reverseorder> \
+struct templatename<MetaPhysicL::NullContainer<NullHeadType>, DualNumber<T, D, asd>, reverseorder> { \
   typedef MetaPhysicL::NullContainer<NullHeadType> supertype; \
 }
 

--- a/src/numerics/include/metaphysicl/dualsparsenumbervector.h
+++ b/src/numerics/include/metaphysicl/dualsparsenumbervector.h
@@ -94,7 +94,7 @@ struct DivergenceVectorFunctor {
   DivergenceVectorFunctor
     (const T* in, typename DerivativeType<T>::type& out) :
       _in(in), _out(out) { out = 0; }
-    
+
   template <typename ValueType>
   inline void operator()() const {
     const unsigned int
@@ -146,9 +146,9 @@ gradient(const SparseNumberVector<T, IndexSet>& a)
 // DualNumber is subordinate to SparseNumberVector
 
 #define DualSparseNumberVector_comparisons(templatename) \
-template<typename T, typename T2, typename D, typename IndexSet, bool reverseorder> \
-struct templatename<SparseNumberVector<T2, IndexSet>, DualNumber<T, D>, reverseorder> { \
-  typedef SparseNumberVector<typename Symmetric##templatename<T2,DualNumber<T, D>,reverseorder>::supertype, IndexSet> supertype; \
+template<typename T, typename T2, typename D, typename IndexSet, bool asd, bool reverseorder> \
+struct templatename<SparseNumberVector<T2, IndexSet>, DualNumber<T, D, asd>, reverseorder> { \
+  typedef SparseNumberVector<typename Symmetric##templatename<T2,DualNumber<T, D,asd>,reverseorder>::supertype, IndexSet> supertype; \
 }
 
 DualSparseNumberVector_comparisons(CompareTypes);

--- a/src/numerics/include/metaphysicl/numberarray.h
+++ b/src/numerics/include/metaphysicl/numberarray.h
@@ -80,6 +80,8 @@ public:
   };
 
   NumberArray() = default;
+  NumberArray(const NumberArray &) = default;
+  NumberArray & operator=(const NumberArray &) = default;
 
   NumberArray(const T& val)
     { std::fill(_data, _data+N, val); }
@@ -88,7 +90,7 @@ public:
     { std::copy(vals, vals+N, _data); }
 
   template <typename T2>
-  NumberArray(NumberArray<N, T2> src)
+  NumberArray(const NumberArray<N, T2> & src)
     { if (N) std::copy(&src[0], &src[0]+N, _data); }
 
   template <typename T2>


### PR DESCRIPTION
I expect this one to be a little controversial. I'd suggest looking at idaholab/moose#14701 for context. We would like to remove templating from the MOOSE AD user experience without sacrificing our current performance. With a `static bool do_derivatives` member we can turn off derivative calculation except when we really want it (e.g. during Jacobian evaluation). The most annoying thing about this to me is "possibly uninitialized` warnings from the compiler, which unfortunately could in cases correspond to "definitely uninitialized". 

I will say that for the `powerlaw_sum` test case in https://github.com/idaholab/moose/pull/14701#issuecomment-587182782, this PR reduces the computation time for a non-sparse derivative container from 55 to 6 seconds, while for a sparse container it reduces from 13 seconds to 6 seconds.