### PR TITLE
Move LT_INIT to before any BOOST macro invocation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -112,6 +112,8 @@ AM_CONDITIONAL(CXX11_ENABLED,test x$HAVE_CXX11 = x1)
 dnl -Wall warnings, -Wall the time.
 AX_CXXFLAGS_WARN_ALL
 
+LT_INIT
+
 dnl---------------------------------------------------------
 dnl Checks for  library prerequisites for other libraries...
 dnl---------------------------------------------------------
@@ -166,8 +168,6 @@ dnl--------------------------
 dnl Checks for code coverage
 dnl--------------------------
 AX_CODE_COVERAGE
-
-LT_INIT
 
 dnl---------------------------------
 dnl Query configuration environment


### PR DESCRIPTION
Boost macros appear to rely on the fact that libtool has already been invoked as indicated by the configure error [here](https://civet.inl.gov/job/477902/):

> checking for the Boost system library... configure: error: the libext variable is empty, did you invoke Libtool?

This appears to be the first time in our test harness MetaPhysicL was able to probe an available BOOST because with the new configure introduced in #58 we pick up the includes and libs available in the conda environment:
```bash
$ mpicxx -show
x86_64-conda_cos6-linux-gnu-c++ -march=nocona -mtune=haswell -Wl,-O2 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,--disable-new-dtags -Wl,--gc-sections -Wl,-rpath,/home/lindad/.conda/envs/moose/lib -Wl,-rpath-link,/home/lindad/.conda/envs/moose/lib -L/home/lindad/.conda/envs/moose/lib -I/home/lindad/.conda/envs/moose/include -L/home/lindad/.conda/envs/moose/lib -lmpicxx -Wl,-rpath -Wl,/home/lindad/.conda/envs/moose/lib -Wl,--enable-new-dtags -lmpi
```